### PR TITLE
fix(import): replace process substitution with temp files for POSIX portability

### DIFF
--- a/scripts/import.sh
+++ b/scripts/import.sh
@@ -214,14 +214,16 @@ import_brain() {
     local new_settings
     new_settings=$(echo "$brain" | jq '.environmental.settings.content // null')
     if [ "$new_settings" != "null" ] && [ -f "${CLAUDE_DIR}/settings.json" ]; then
-      local tmp
+      local tmp tmp_remote
       tmp=$(brain_mktemp)
+      tmp_remote=$(brain_mktemp)
+      echo "$new_settings" > "$tmp_remote"
       # Merge: keep local env and mcpServers, merge everything else from consolidated
       jq -s '.[0] as $local | .[1] as $remote |
         ($local.env // {}) as $local_env |
         ($local.mcpServers // {}) as $local_mcp |
         ($remote // {}) * $local | .env = $local_env | .mcpServers = $local_mcp' \
-        "${CLAUDE_DIR}/settings.json" <(echo "$new_settings") > "$tmp"
+        "${CLAUDE_DIR}/settings.json" "$tmp_remote" > "$tmp"
       mv "$tmp" "${CLAUDE_DIR}/settings.json"
       chmod 600 "${CLAUDE_DIR}/settings.json"
       log_info "Updated: settings.json (merged, local env and mcpServers preserved)"
@@ -236,10 +238,12 @@ import_brain() {
     new_keybindings=$(echo "$brain" | jq '.environmental.keybindings.content // null')
     if [ "$new_keybindings" != "null" ]; then
       if [ -f "${CLAUDE_DIR}/keybindings.json" ]; then
-        local tmp
+        local tmp tmp_remote_kb
         tmp=$(brain_mktemp)
+        tmp_remote_kb=$(brain_mktemp)
+        echo "$new_keybindings" > "$tmp_remote_kb"
         # Union keybindings arrays (deduplicate by key+command)
-        jq -s '.[0] + .[1] | unique_by(.key, .command)' "${CLAUDE_DIR}/keybindings.json" <(echo "$new_keybindings") > "$tmp"
+        jq -s '.[0] + .[1] | unique_by(.key, .command)' "${CLAUDE_DIR}/keybindings.json" "$tmp_remote_kb" > "$tmp"
         mv "$tmp" "${CLAUDE_DIR}/keybindings.json"
         log_info "Updated: keybindings.json (merged)"
       else

--- a/scripts/import.sh
+++ b/scripts/import.sh
@@ -217,7 +217,7 @@ import_brain() {
       local tmp tmp_remote
       tmp=$(brain_mktemp)
       tmp_remote=$(brain_mktemp)
-      echo "$new_settings" > "$tmp_remote"
+      printf '%s\n' "$new_settings" > "$tmp_remote"
       # Merge: keep local env and mcpServers, merge everything else from consolidated
       jq -s '.[0] as $local | .[1] as $remote |
         ($local.env // {}) as $local_env |
@@ -241,7 +241,7 @@ import_brain() {
         local tmp tmp_remote_kb
         tmp=$(brain_mktemp)
         tmp_remote_kb=$(brain_mktemp)
-        echo "$new_keybindings" > "$tmp_remote_kb"
+        printf '%s\n' "$new_keybindings" > "$tmp_remote_kb"
         # Union keybindings arrays (deduplicate by key+command)
         jq -s '.[0] + .[1] | unique_by(.key, .command)' "${CLAUDE_DIR}/keybindings.json" "$tmp_remote_kb" > "$tmp"
         mv "$tmp" "${CLAUDE_DIR}/keybindings.json"


### PR DESCRIPTION
## Problem

The `import.sh` script uses bash process substitution `<(echo "$var")` in
two places to pass JSON data to `jq -s`:

- Settings merge (line 224): `<(echo "$new_settings")`
- Keybindings merge (line 242): `<(echo "$new_keybindings")`

Process substitution relies on `/proc/self/fd` which is not available on
all platforms. Specifically, MINGW (Git Bash on Windows) does not support
`/proc` file descriptors, causing `jq` to fail with "No such file or
directory" errors.

## Root Cause

Bash process substitution `<(...)` creates a temporary file descriptor
under `/proc/self/fd/`. While this works on Linux and macOS, MINGW's
emulation layer does not implement `/proc/self/fd`, making the file
descriptor path unresolvable by external tools like `jq`.

## Solution

Write the JSON data to temporary files using the existing `brain_mktemp`
helper, then pass the file path to `jq` as a regular argument:

```bash
# Before
jq -s '...' file1.json <(echo "$data") > output

# After
tmp_remote=$(brain_mktemp)
echo "$data" > "$tmp_remote"
jq -s '...' file1.json "$tmp_remote" > output
```

This uses the project's own `brain_mktemp` function for consistent temp
file management and cleanup.

## Testing

1. Run `import.sh` on Linux/macOS — behavior unchanged
2. Run `import.sh` on Windows Git Bash (MINGW) — settings and keybindings
   merge now works correctly instead of failing

## Compatibility

No impact on existing functionality. Temp files are managed by the existing
`brain_mktemp` infrastructure and cleaned up on exit. The jq merge logic
is identical — only the input mechanism changes.