### PR TITLE
fix: read/write MCP servers from ~/.claude.json instead of settings.json

### DIFF
--- a/scripts/export.sh
+++ b/scripts/export.sh
@@ -151,10 +151,10 @@ build_snapshot() {
       done | jq -s 'add // {}')
   fi
 
-  # Environmental: settings (strip env vars AND mcpServers — MCP exported separately)
+  # Environmental: settings (strip env vars — mcpServers live in ~/.claude.json, not here)
   local settings="null"
   if [ -f "${CLAUDE_DIR}/settings.json" ]; then
-    settings=$(jq 'del(.env) | del(.mcpServers)' "${CLAUDE_DIR}/settings.json")
+    settings=$(jq 'del(.env)' "${CLAUDE_DIR}/settings.json")
   fi
 
   local settings_hash="null"
@@ -170,16 +170,18 @@ build_snapshot() {
     keybindings_hash=$(file_hash "${CLAUDE_DIR}/keybindings.json")
   fi
 
-  # Environmental: MCP servers (from settings.json mcpServers field)
+  # Environmental: MCP servers (from ~/.claude.json, NOT settings.json)
+  # Claude Code stores mcpServers in ~/.claude.json (CLAUDE_JSON),
+  # while settings.json only contains MCP policy fields.
   # SECURITY: Strip env fields from each server config (may contain API keys/tokens)
   local mcp_servers="{}"
-  if [ -f "${CLAUDE_DIR}/settings.json" ]; then
+  if [ -f "${CLAUDE_JSON}" ]; then
     mcp_servers=$(jq '
       .mcpServers // {} |
       to_entries |
       map(.value = (.value | del(.env))) |
       from_entries
-    ' "${CLAUDE_DIR}/settings.json" 2>/dev/null || echo "{}")
+    ' "${CLAUDE_JSON}" 2>/dev/null || echo "{}")
     # Rewrite absolute home paths to ${HOME}
     mcp_servers=$(echo "$mcp_servers" | sed "s|${HOME}|\${HOME}|g")
   fi

--- a/scripts/import.sh
+++ b/scripts/import.sh
@@ -210,7 +210,8 @@ import_brain() {
       import_dir_entries "${CLAUDE_DIR}/agent-memory/${agent}" "$entries"
     done
 
-  # Environmental: settings (deep merge, preserve local env AND local mcpServers)
+  # Environmental: settings (deep merge, preserve local env)
+  # Note: mcpServers are NOT in settings.json — they live in ~/.claude.json (CLAUDE_JSON)
     local new_settings
     new_settings=$(echo "$brain" | jq '.environmental.settings.content // null')
     if [ "$new_settings" != "null" ] && [ -f "${CLAUDE_DIR}/settings.json" ]; then
@@ -218,19 +219,50 @@ import_brain() {
       tmp=$(brain_mktemp)
       tmp_remote=$(brain_mktemp)
       printf '%s\n' "$new_settings" > "$tmp_remote"
-      # Merge: keep local env and mcpServers, merge everything else from consolidated
+      # Merge: keep local env, merge everything else from consolidated
+      # Note: mcpServers are NOT in settings.json — they live in ~/.claude.json (CLAUDE_JSON)
       jq -s '.[0] as $local | .[1] as $remote |
         ($local.env // {}) as $local_env |
-        ($local.mcpServers // {}) as $local_mcp |
-        ($remote // {}) * $local | .env = $local_env | .mcpServers = $local_mcp' \
+        ($remote // {}) * $local | .env = $local_env' \
         "${CLAUDE_DIR}/settings.json" "$tmp_remote" > "$tmp"
       mv "$tmp" "${CLAUDE_DIR}/settings.json"
       chmod 600 "${CLAUDE_DIR}/settings.json"
-      log_info "Updated: settings.json (merged, local env and mcpServers preserved)"
+      log_info "Updated: settings.json (merged, local env preserved)"
     elif [ "$new_settings" != "null" ] && [ ! -f "${CLAUDE_DIR}/settings.json" ]; then
       echo "$new_settings" > "${CLAUDE_DIR}/settings.json"
       chmod 600 "${CLAUDE_DIR}/settings.json"
       log_info "Created: settings.json"
+    fi
+
+  # Environmental: MCP servers (merge into ~/.claude.json, preserve local env)
+  # Claude Code stores mcpServers in ~/.claude.json (CLAUDE_JSON), not settings.json.
+  # Expand ${HOME} placeholders back to actual paths before writing.
+    local new_mcp_servers
+    new_mcp_servers=$(echo "$brain" | jq '.environmental.mcp_servers // {}')
+    if [ "$new_mcp_servers" != "{}" ] && [ "$new_mcp_servers" != "null" ]; then
+      # Expand ${HOME} placeholders to actual HOME path
+      new_mcp_servers=$(echo "$new_mcp_servers" | sed "s|\\\${HOME}|${HOME}|g")
+      if [ -f "${CLAUDE_JSON}" ]; then
+        local tmp
+        tmp=$(brain_mktemp)
+        # Merge: combine remote MCP servers with local ones (local takes precedence),
+        # preserve all other fields in ~/.claude.json including local env vars
+        local tmp_mcp
+        tmp_mcp=$(brain_mktemp)
+        printf '%s\n' "$new_mcp_servers" > "$tmp_mcp"
+        jq -s '.[0] as $local | .[1] as $remote_mcp |
+          ($local.mcpServers // {}) as $local_mcp |
+          $local | .mcpServers = ($remote_mcp * $local_mcp)' \
+          "${CLAUDE_JSON}" "$tmp_mcp" > "$tmp"
+        mv "$tmp" "${CLAUDE_JSON}"
+        chmod 600 "${CLAUDE_JSON}"
+        log_info "Updated: ~/.claude.json (MCP servers merged, local overrides preserved)"
+      else
+        # Create ~/.claude.json with just mcpServers
+        jq -n --argjson mcp "$new_mcp_servers" '{"mcpServers": $mcp}' > "${CLAUDE_JSON}"
+        chmod 600 "${CLAUDE_JSON}"
+        log_info "Created: ~/.claude.json with MCP servers"
+      fi
     fi
 
   # Environmental: keybindings (union)


### PR DESCRIPTION
## Summary

Fixes #23 — MCP servers were never exported/synced because `export.sh` read `mcpServers` from `~/.claude/settings.json`, but Claude Code stores them in `~/.claude.json`.

## The Bug

- `export.sh` read MCP server configs from `~/.claude/settings.json`
- Claude Code stores `mcpServers` in `~/.claude.json` (the root-level config file)
- `settings.json` only has MCP *policy* fields (`enableAllProjectMcpServers`, etc.)
- Result: MCP servers always showed "0 items" during export/sync
- `import.sh` also incorrectly referenced `mcpServers` in its `settings.json` merge logic

## Changes

### `export.sh`
- Read `mcpServers` from `CLAUDE_JSON` (`~/.claude.json`) instead of `settings.json`
- Remove unnecessary `del(.mcpServers)` from settings export (mcpServers was never in settings.json)
- Env vars still stripped from exported MCP configs (security)
- HOME paths still normalized to `\${HOME}` placeholder

### `import.sh`
- Add new MCP server import section that writes to `~/.claude.json` (`CLAUDE_JSON`)
- Properly expands `\${HOME}` placeholders back to actual paths on import
- Local MCP servers take precedence over remote ones during merge
- Preserves all other fields in `~/.claude.json`
- Remove `mcpServers` references from `settings.json` merge (they don't belong there)

## Testing

Tested end-to-end with mock config files:
- ✅ Export reads MCP servers from `~/.claude.json` (2 servers exported correctly)
- ✅ Env vars stripped from exported MCP configs
- ✅ HOME paths normalized to `\${HOME}` on export
- ✅ Import creates `~/.claude.json` with MCP servers on clean machine
- ✅ HOME placeholders expanded to actual paths on import
- ✅ No env vars leaked into imported configs
- ✅ Local MCP servers preserved during re-import (3 total: 2 remote + 1 local)
- ✅ `settings.json` does not contain `mcpServers`