### PR TITLE
fix: add skills/agents/hooks to plugin.json, fix install name in README

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,5 +9,20 @@
   "homepage": "https://github.com/toroleapinc/claude-brain",
   "repository": "https://github.com/toroleapinc/claude-brain",
   "license": "MIT",
-  "keywords": ["sync", "memory", "brain", "multi-machine", "merge", "productivity", "dotfiles", "cross-device"]
+  "keywords": ["sync", "memory", "brain", "multi-machine", "merge", "productivity", "dotfiles", "cross-device"],
+  "skills": [
+    "./skills/brain-init",
+    "./skills/brain-join",
+    "./skills/brain-sync",
+    "./skills/brain-status",
+    "./skills/brain-evolve",
+    "./skills/brain-conflicts",
+    "./skills/brain-share",
+    "./skills/brain-shared-list",
+    "./skills/brain-log"
+  ],
+  "agents": [
+    "./agents/brain-merge.md"
+  ],
+  "hooks": "./hooks/hooks.json"
 }

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Two commands. Zero daily effort. Works forever.
 ```bash
 # Add the marketplace and install
 /plugin marketplace add toroleapinc/claude-brain
-/plugin install claude-brain
+/plugin install claude-brain-sync
 ```
 
 ### Initialize (first machine)

--- a/docs/i18n/README.zh.md
+++ b/docs/i18n/README.zh.md
@@ -68,7 +68,7 @@
 ```bash
 # 从插件市场安装
 /plugin marketplace add toroleapinc/claude-brain
-/plugin install claude-brain
+/plugin install claude-brain-sync
 ```
 
 ### 初始化（第一台设备）

--- a/scripts/export.sh
+++ b/scripts/export.sh
@@ -151,10 +151,10 @@ build_snapshot() {
       done | jq -s 'add // {}')
   fi
 
-  # Environmental: settings (strip env vars AND mcpServers — MCP exported separately)
+  # Environmental: settings (strip env vars — mcpServers live in ~/.claude.json, not here)
   local settings="null"
   if [ -f "${CLAUDE_DIR}/settings.json" ]; then
-    settings=$(jq 'del(.env) | del(.mcpServers)' "${CLAUDE_DIR}/settings.json")
+    settings=$(jq 'del(.env)' "${CLAUDE_DIR}/settings.json")
   fi
 
   local settings_hash="null"
@@ -170,16 +170,18 @@ build_snapshot() {
     keybindings_hash=$(file_hash "${CLAUDE_DIR}/keybindings.json")
   fi
 
-  # Environmental: MCP servers (from settings.json mcpServers field)
+  # Environmental: MCP servers (from ~/.claude.json, NOT settings.json)
+  # Claude Code stores mcpServers in ~/.claude.json (CLAUDE_JSON),
+  # while settings.json only contains MCP policy fields.
   # SECURITY: Strip env fields from each server config (may contain API keys/tokens)
   local mcp_servers="{}"
-  if [ -f "${CLAUDE_DIR}/settings.json" ]; then
+  if [ -f "${CLAUDE_JSON}" ]; then
     mcp_servers=$(jq '
       .mcpServers // {} |
       to_entries |
       map(.value = (.value | del(.env))) |
       from_entries
-    ' "${CLAUDE_DIR}/settings.json" 2>/dev/null || echo "{}")
+    ' "${CLAUDE_JSON}" 2>/dev/null || echo "{}")
     # Rewrite absolute home paths to ${HOME}
     mcp_servers=$(echo "$mcp_servers" | sed "s|${HOME}|\${HOME}|g")
   fi

--- a/scripts/import.sh
+++ b/scripts/import.sh
@@ -210,7 +210,8 @@ import_brain() {
       import_dir_entries "${CLAUDE_DIR}/agent-memory/${agent}" "$entries"
     done
 
-  # Environmental: settings (deep merge, preserve local env AND local mcpServers)
+  # Environmental: settings (deep merge, preserve local env)
+  # Note: mcpServers are NOT in settings.json — they live in ~/.claude.json (CLAUDE_JSON)
     local new_settings
     new_settings=$(echo "$brain" | jq '.environmental.settings.content // null')
     if [ "$new_settings" != "null" ] && [ -f "${CLAUDE_DIR}/settings.json" ]; then
@@ -218,19 +219,50 @@ import_brain() {
       tmp=$(brain_mktemp)
       tmp_remote=$(brain_mktemp)
       printf '%s\n' "$new_settings" > "$tmp_remote"
-      # Merge: keep local env and mcpServers, merge everything else from consolidated
+      # Merge: keep local env, merge everything else from consolidated
+      # Note: mcpServers are NOT in settings.json — they live in ~/.claude.json (CLAUDE_JSON)
       jq -s '.[0] as $local | .[1] as $remote |
         ($local.env // {}) as $local_env |
-        ($local.mcpServers // {}) as $local_mcp |
-        ($remote // {}) * $local | .env = $local_env | .mcpServers = $local_mcp' \
+        ($remote // {}) * $local | .env = $local_env' \
         "${CLAUDE_DIR}/settings.json" "$tmp_remote" > "$tmp"
       mv "$tmp" "${CLAUDE_DIR}/settings.json"
       chmod 600 "${CLAUDE_DIR}/settings.json"
-      log_info "Updated: settings.json (merged, local env and mcpServers preserved)"
+      log_info "Updated: settings.json (merged, local env preserved)"
     elif [ "$new_settings" != "null" ] && [ ! -f "${CLAUDE_DIR}/settings.json" ]; then
       echo "$new_settings" > "${CLAUDE_DIR}/settings.json"
       chmod 600 "${CLAUDE_DIR}/settings.json"
       log_info "Created: settings.json"
+    fi
+
+  # Environmental: MCP servers (merge into ~/.claude.json, preserve local env)
+  # Claude Code stores mcpServers in ~/.claude.json (CLAUDE_JSON), not settings.json.
+  # Expand ${HOME} placeholders back to actual paths before writing.
+    local new_mcp_servers
+    new_mcp_servers=$(echo "$brain" | jq '.environmental.mcp_servers // {}')
+    if [ "$new_mcp_servers" != "{}" ] && [ "$new_mcp_servers" != "null" ]; then
+      # Expand ${HOME} placeholders to actual HOME path
+      new_mcp_servers=$(echo "$new_mcp_servers" | sed "s|\\\${HOME}|${HOME}|g")
+      if [ -f "${CLAUDE_JSON}" ]; then
+        local tmp
+        tmp=$(brain_mktemp)
+        # Merge: combine remote MCP servers with local ones (local takes precedence),
+        # preserve all other fields in ~/.claude.json including local env vars
+        local tmp_mcp
+        tmp_mcp=$(brain_mktemp)
+        printf '%s\n' "$new_mcp_servers" > "$tmp_mcp"
+        jq -s '.[0] as $local | .[1] as $remote_mcp |
+          ($local.mcpServers // {}) as $local_mcp |
+          $local | .mcpServers = ($remote_mcp * $local_mcp)' \
+          "${CLAUDE_JSON}" "$tmp_mcp" > "$tmp"
+        mv "$tmp" "${CLAUDE_JSON}"
+        chmod 600 "${CLAUDE_JSON}"
+        log_info "Updated: ~/.claude.json (MCP servers merged, local overrides preserved)"
+      else
+        # Create ~/.claude.json with just mcpServers
+        jq -n --argjson mcp "$new_mcp_servers" '{"mcpServers": $mcp}' > "${CLAUDE_JSON}"
+        chmod 600 "${CLAUDE_JSON}"
+        log_info "Created: ~/.claude.json with MCP servers"
+      fi
     fi
 
   # Environmental: keybindings (union)


### PR DESCRIPTION
## Summary

Fixes #24 — Plugin installation broken: `plugin.json` missing required fields + README uses wrong plugin name.

## Changes

### 1. `.claude-plugin/plugin.json` — added component paths

Added the `skills`, `agents`, and `hooks` fields so Claude Code discovers all plugin components on install:

- **9 skills**: brain-init, brain-join, brain-sync, brain-status, brain-evolve, brain-conflicts, brain-share, brain-shared-list, brain-log
- **1 agent**: brain-merge
- **hooks**: hooks.json (SessionStart, SessionEnd, PreCompact)

Without these fields, `/reload-plugins` shows "0 skills" and slash commands like `/brain-join` never appear.

### 2. README.md + docs/i18n/README.zh.md — fixed install command

Changed:
```
/plugin install claude-brain
```
To:
```
/plugin install claude-brain-sync
```

The plugin name in `plugin.json` is `claude-brain-sync`, so the install command must match.

## Testing

- ✅ `plugin.json` is valid JSON
- ✅ All 9 skill directories exist at listed paths
- ✅ Agent file exists at listed path
- ✅ hooks.json exists at listed path
- ✅ README install instructions are consistent with plugin name