### PR TITLE
fix: preserve sync timestamps on re-registration

### DIFF
--- a/scripts/register-machine.sh
+++ b/scripts/register-machine.sh
@@ -30,6 +30,18 @@ register_machine() {
   os_type=$(detect_os)
   timestamp=$(now_iso)
 
+  # Preserve sync timestamps from existing config so re-registration doesn't wipe them
+  local last_push="null" last_pull="null" last_evolved="null"
+  if [ -f "$BRAIN_CONFIG" ]; then
+    local _lp _lpull _le
+    _lp=$(jq -r '.last_push // "null"' "$BRAIN_CONFIG")
+    _lpull=$(jq -r '.last_pull // "null"' "$BRAIN_CONFIG")
+    _le=$(jq -r '.last_evolved // "null"' "$BRAIN_CONFIG")
+    [ "$_lp" != "null" ] && last_push="\"${_lp}\""
+    [ "$_lpull" != "null" ] && last_pull="\"${_lpull}\""
+    [ "$_le" != "null" ] && last_evolved="\"${_le}\""
+  fi
+
   # Discover tracked projects
   local projects="[]"
   if [ -d "${CLAUDE_DIR}/projects" ]; then
@@ -55,6 +67,9 @@ register_machine() {
         --arg repo "$BRAIN_REPO" \
         --argjson sync true \
         --arg ts "$timestamp" \
+        --argjson lp "$last_push" \
+        --argjson lpull "$last_pull" \
+        --argjson le "$last_evolved" \
         --arg identity "${HOME}/.claude/brain-age-key.txt" \
         --arg recipients "${BRAIN_REPO}/meta/recipients.txt" \
         '{
@@ -66,9 +81,9 @@ register_machine() {
           brain_repo_path: $repo,
           auto_sync: $sync,
           registered_at: $ts,
-          last_push: null,
-          last_pull: null,
-          last_evolved: null,
+          last_push: $lp,
+          last_pull: $lpull,
+          last_evolved: $le,
           dirty: false,
           encryption: {
             enabled: true,
@@ -86,6 +101,9 @@ register_machine() {
         --arg repo "$BRAIN_REPO" \
         --argjson sync true \
         --arg ts "$timestamp" \
+        --argjson lp "$last_push" \
+        --argjson lpull "$last_pull" \
+        --argjson le "$last_evolved" \
         '{
           version: $ver,
           remote: $remote,
@@ -95,9 +113,9 @@ register_machine() {
           brain_repo_path: $repo,
           auto_sync: $sync,
           registered_at: $ts,
-          last_push: null,
-          last_pull: null,
-          last_evolved: null,
+          last_push: $lp,
+          last_pull: $lpull,
+          last_evolved: $le,
           dirty: false,
           encryption: {
             enabled: false

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -744,6 +744,55 @@ EOF
   fi
 }
 
+test_register_machine_preserves_timestamps() {
+  section "register-machine.sh preserves existing sync timestamps"
+
+  # Initial registration (creates brain-config.json from scratch)
+  rm -f "$BRAIN_CONFIG"
+  bash "$PROJECT_DIR/scripts/register-machine.sh" "git@github.com:test/test.git" 2>/dev/null || true
+
+  if [ ! -f "$BRAIN_CONFIG" ]; then
+    fail "brain-config.json not created on first registration"
+    return
+  fi
+
+  # Seed known timestamps into the config
+  local known_push="2025-01-15T10:00:00Z"
+  local known_pull="2025-01-14T09:00:00Z"
+  local known_evolved="2025-01-13T08:00:00Z"
+  json_set "$BRAIN_CONFIG" "last_push" "$known_push"
+  json_set "$BRAIN_CONFIG" "last_pull" "$known_pull"
+  json_set "$BRAIN_CONFIG" "last_evolved" "$known_evolved"
+
+  # Re-register (simulates what push.sh does mid-run to update machines.json)
+  bash "$PROJECT_DIR/scripts/register-machine.sh" "git@github.com:test/test.git" 2>/dev/null || true
+
+  local actual_push actual_pull actual_evolved
+  actual_push=$(jqr ".last_push" "$BRAIN_CONFIG")
+  actual_pull=$(jqr ".last_pull" "$BRAIN_CONFIG")
+  actual_evolved=$(jqr ".last_evolved" "$BRAIN_CONFIG")
+
+  [ "$actual_push" = "$known_push" ] \
+    && pass "last_push preserved after re-registration" \
+    || fail "last_push wiped by re-registration (got '$actual_push', expected '$known_push')"
+
+  [ "$actual_pull" = "$known_pull" ] \
+    && pass "last_pull preserved after re-registration" \
+    || fail "last_pull wiped by re-registration (got '$actual_pull', expected '$known_pull')"
+
+  [ "$actual_evolved" = "$known_evolved" ] \
+    && pass "last_evolved preserved after re-registration" \
+    || fail "last_evolved wiped by re-registration (got '$actual_evolved', expected '$known_evolved')"
+
+  # Verify null stays null on a brand-new config (never pushed)
+  rm -f "$BRAIN_CONFIG"
+  bash "$PROJECT_DIR/scripts/register-machine.sh" "git@github.com:test/test.git" 2>/dev/null || true
+  actual_push=$(jqr ".last_push" "$BRAIN_CONFIG")
+  [ "$actual_push" = "null" ] \
+    && pass "last_push is null on fresh registration (never pushed)" \
+    || fail "last_push should be null on fresh registration (got '$actual_push')"
+}
+
 # ── Run ────────────────────────────────────────────────────────────────────────
 echo -e "${CYAN}claude-brain integration tests${NC}"
 echo "================================"
@@ -762,6 +811,7 @@ test_secret_scanning
 test_export_import_roundtrip
 test_structured_merge
 test_register_machine
+test_register_machine_preserves_timestamps
 test_shared_namespace
 test_auto_evolve_trigger
 test_path_traversal_blocked


### PR DESCRIPTION
## Summary

Fixes a bug where `last_push`, `last_pull`, and `last_evolved` in `brain-config.json` are permanently `null` — even after successful pushes.

### Root cause

`push.sh` calls `register-machine.sh` mid-run to update `machines.json`. `register-machine.sh` unconditionally rebuilds `brain-config.json` from scratch, hardcoding `last_push: null`, `last_pull: null`, and `last_evolved: null`. While `push.sh` has a writeback at the end to restore the timestamp, if `push.sh` is invoked a second time with no changes it exits early (nothing to commit) before reaching the writeback — leaving all three fields permanently `null`.

### Fix

Read the existing timestamp values from `brain-config.json` before rebuilding the config and pass them through via `--argjson`.

### Deconfliction

Note: this PR previously also included a fix for the macOS BSD `sed` + `\x00` issue in `decode_project_path`. That fix has been **removed** from this PR — PR #21 already covers it. This PR now only touches `scripts/register-machine.sh` and `tests/run-tests.sh`.

## Test plan

Added `test_register_machine_preserves_timestamps` to `tests/run-tests.sh` with 4 assertions:
- `last_push` preserved after re-registration ✓
- `last_pull` preserved after re-registration ✓
- `last_evolved` preserved after re-registration ✓
- `last_push` stays `null` on a fresh registration (never pushed) ✓

Full suite: **44 passed, 0 failed, 0 skipped**

```
bash tests/run-tests.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)