### PR TITLE
fix: plugin fails to load skills and sync after fresh install

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -10,19 +10,7 @@
   "repository": "https://github.com/toroleapinc/claude-brain",
   "license": "MIT",
   "keywords": ["sync", "memory", "brain", "multi-machine", "merge", "productivity", "dotfiles", "cross-device"],
-  "skills": [
-    "./skills/brain-init",
-    "./skills/brain-join",
-    "./skills/brain-sync",
-    "./skills/brain-status",
-    "./skills/brain-evolve",
-    "./skills/brain-conflicts",
-    "./skills/brain-share",
-    "./skills/brain-shared-list",
-    "./skills/brain-log"
-  ],
   "agents": [
     "./agents/brain-merge.md"
-  ],
-  "hooks": "./hooks/hooks.json"
+  ]
 }

--- a/scripts/push.sh
+++ b/scripts/push.sh
@@ -50,8 +50,9 @@ fi
 # Update machines.json with last sync time
 "${SCRIPT_DIR}/register-machine.sh" "$(get_config remote)"
 
-# Commit and push
-brain_git add "machines/${machine_id}/" "meta/machines.json" "shared/" 2>/dev/null || true
+# Commit and push (add paths separately so missing shared/ doesn't block others)
+brain_git add "machines/${machine_id}/" "meta/machines.json" 2>/dev/null || true
+brain_git add "shared/" 2>/dev/null || true
 brain_git commit -m "Sync: $(get_machine_name) (${machine_id}) at $(now_iso)" 2>/dev/null || {
   log_info "Nothing to commit."
   exit 0

--- a/skills/brain-conflicts/SKILL.md
+++ b/skills/brain-conflicts/SKILL.md
@@ -1,10 +1,8 @@
 ---
 name: brain-conflicts
 description: Review and resolve unresolved brain merge conflicts.
-user-invocable: true
-disable-model-invocation: true
-allowed-tools: Bash, Read, Write, Edit, AskUserQuestion
 ---
+
 
 The user wants to resolve pending brain merge conflicts.
 

--- a/skills/brain-evolve/SKILL.md
+++ b/skills/brain-evolve/SKILL.md
@@ -1,10 +1,8 @@
 ---
 name: brain-evolve
 description: Analyze accumulated brain memory and propose promotions to CLAUDE.md, rules, or new skills. Makes your brain smarter over time.
-user-invocable: true
-disable-model-invocation: true
-allowed-tools: Bash, Read, Write, Edit, AskUserQuestion
 ---
+
 
 The user wants to evolve their brain by promoting stable patterns from memory.
 

--- a/skills/brain-init/SKILL.md
+++ b/skills/brain-init/SKILL.md
@@ -1,11 +1,8 @@
 ---
 name: brain-init
 description: Initialize brain sync network. Creates a Git remote for your brain and exports your current Claude Code state.
-user-invocable: true
-disable-model-invocation: true
-argument-hint: "<git-remote-url> [--encrypt]"
-allowed-tools: Bash, Read, Write, AskUserQuestion
 ---
+
 
 The user wants to initialize their Claude Brain sync network.
 

--- a/skills/brain-join/SKILL.md
+++ b/skills/brain-join/SKILL.md
@@ -1,11 +1,8 @@
 ---
 name: brain-join
 description: Join an existing brain sync network from another machine. Pulls the consolidated brain and merges with any local state.
-user-invocable: true
-disable-model-invocation: true
-argument-hint: "<git-remote-url>"
-allowed-tools: Bash, Read, Write, Edit, AskUserQuestion
 ---
+
 
 The user wants to join an existing brain network from this machine.
 

--- a/skills/brain-log/SKILL.md
+++ b/skills/brain-log/SKILL.md
@@ -1,10 +1,8 @@
 ---
 name: brain-log
 description: Show brain sync and evolution history.
-user-invocable: true
-disable-model-invocation: true
-allowed-tools: Bash, Read
 ---
+
 
 Show the user their brain's sync history.
 

--- a/skills/brain-share/SKILL.md
+++ b/skills/brain-share/SKILL.md
@@ -1,11 +1,8 @@
 ---
 name: brain-share
 description: Share a skill, agent, or rule with the team by copying it to the shared namespace
-user-invocable: true
-disable-model-invocation: true
-argument-hint: "<type> <name>"
-allowed-tools: Bash, Read, Write
 ---
+
 
 Share an artifact with the team by copying it to the shared namespace.
 

--- a/skills/brain-shared-list/SKILL.md
+++ b/skills/brain-shared-list/SKILL.md
@@ -1,10 +1,8 @@
 ---
 name: brain-shared-list
 description: List all shared skills, agents, and rules in the brain network.
-user-invocable: true
-disable-model-invocation: true
-allowed-tools: Bash, Read
 ---
+
 
 The user wants to see all shared artifacts in the brain network.
 

--- a/skills/brain-status/SKILL.md
+++ b/skills/brain-status/SKILL.md
@@ -1,10 +1,8 @@
 ---
 name: brain-status
 description: Show brain inventory, sync status, and network info across all machines.
-user-invocable: true
-disable-model-invocation: true
-allowed-tools: Bash, Read
 ---
+
 
 Show the user their brain status.
 

--- a/skills/brain-sync/SKILL.md
+++ b/skills/brain-sync/SKILL.md
@@ -1,10 +1,8 @@
 ---
 name: brain-sync
 description: Manually sync brain with remote. Exports local state, pushes to remote, pulls updates from other machines, merges, and applies.
-user-invocable: true
-disable-model-invocation: true
-allowed-tools: Bash, Read, Write, Edit
 ---
+
 
 The user wants to manually trigger a full brain sync cycle.
 


### PR DESCRIPTION
## Summary

After a fresh `/plugin install claude-brain-sync`, the plugin is non-functional due to three bugs:

- **Duplicate hooks error**: `plugin.json` declares `"hooks": "./hooks/hooks.json"` but Claude Code auto-discovers `hooks/hooks.json` by default, causing a "Duplicate hooks file detected" error on `/reload-plugins`. Removed the explicit hooks field — the default auto-discovery is sufficient.

- **0 skills loaded**: `plugin.json` has a `"skills"` field which is not a recognized `plugin.json` property (skills are auto-discovered from `skills/`). Additionally, all 9 `SKILL.md` files contain non-standard frontmatter fields (`user-invocable`, `disable-model-invocation`, `argument-hint`, `allowed-tools`) that prevent Claude Code from parsing them. Removed the `skills` field and stripped non-standard frontmatter from all SKILL.md files — only `name` and `description` are kept, matching the format used by official plugins.

- **push.sh silent failure**: `git add` on line 54 combines `machines/`, `meta/`, and `shared/` in one command. If `shared/` doesn't exist (common for new users who haven't used `/brain-share`), the entire `git add` fails silently (`2>/dev/null || true`), so no files get staged. Split into separate `git add` calls so a missing `shared/` doesn't block the other paths.

## References

- Bug 1 was introduced in #28 (commit 5efa035)
- Bug 2 was also introduced in #28
- Bug 3 predates #28

## Test plan

- [ ] Fresh install: `/plugin marketplace add toroleapinc/claude-brain` → `/plugin install claude-brain-sync` → `/reload-plugins` should show 0 errors and 9 skills visible via `/brain-init`
- [ ] `/brain-init <remote>` completes successfully
- [ ] `/brain-sync` push phase stages and commits changes (even without `shared/` directory)
- [ ] Tested on Claude Code 2.1.105 (Linux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)