### PR TITLE
macOS compat: decode_project_path, ARG_MAX, .env leak

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -565,10 +565,16 @@ list_backups() {
 # Hyphens in names are doubled: my-project → my--project
 # Leading slash becomes leading hyphen
 decode_project_path() {
-  local encoded="$1"
-  # First restore leading slash, then un-double hyphens temporarily,
-  # then convert remaining single hyphens to slashes, then restore hyphens
-  echo "$encoded" | sed 's/^-/\//' | sed 's/--/\x00/g' | sed 's/-/\//g' | sed 's/\x00/-/g'
+  # Bash parameter expansion — portable across BSD sed (macOS) and GNU sed.
+  # The prior `sed 's/\x00/.../'` form silently returned empty string on BSD sed,
+  # collapsing every project_name key to "" and destroying multi-project memory
+  # exports. No subprocess spawned → also faster.
+  local s="$1"
+  [[ "$s" == -* ]] && s="/${s:1}"          # leading - → /
+  s="${s//--/__DD_SENTINEL__}"              # protect doubled dashes
+  s="${s//-//}"                             # remaining dashes → slashes
+  s="${s//__DD_SENTINEL__/-}"               # restore original dashes
+  echo "$s"
 }
 
 encode_project_path() {

--- a/scripts/export.sh
+++ b/scripts/export.sh
@@ -51,7 +51,13 @@ scan_dir_entries() {
   fi
 
     local scan_result
-    scan_result=$(find "$dir" -type f 2>/dev/null | sort | while read -r f; do
+    # Prune hidden dirs (.venv, .git, .cache), package dirs, and skip dotfiles + *.env
+    # The dotfile exclusion is critical: .env files commonly hold API keys and must
+    # never reach the brain snapshot (which is pushed to a Git remote).
+    scan_result=$(find "$dir" \
+        \( -type d \( -name ".*" -o -name "node_modules" -o -name "__pycache__" -o -name "venv" \) -prune \) \
+        -o \( -type f ! -name ".*" ! -name "*.env" ! -name "*.pem" ! -name "*.key" -print \) \
+        2>/dev/null | sort | while read -r f; do
       # Size guard per file
       if ! check_file_size "$f" 2>/dev/null; then
         continue
@@ -190,55 +196,73 @@ build_snapshot() {
   fi
 
   # Assemble full snapshot
-    jq -n \
-      --arg schema_ver "1.0.0" \
-      --arg ts "$timestamp" \
-      --arg mid "$machine_id" \
-      --arg mn "$machine_name" \
-      --arg os "$os_type" \
-      --argjson claude_md "${claude_md:-null}" \
-      --argjson rules "$rules" \
-      --argjson skills "$skills" \
-      --argjson agents "$agents" \
-      --argjson output_styles "$output_styles" \
-      --argjson auto_memory "$auto_memory" \
-      --argjson agent_memory "$agent_memory" \
-      --argjson settings "${settings:-null}" \
-      --arg settings_hash "${settings_hash}" \
-      --argjson keybindings "${keybindings:-null}" \
-      --arg keybindings_hash "${keybindings_hash}" \
-      --argjson mcp_servers "$mcp_servers" \
-      --argjson shared_skills "$shared_skills" \
-      --argjson shared_agents "$shared_agents" \
-      --argjson shared_rules "$shared_rules" \
-      '{
-        schema_version: $schema_ver,
-        exported_at: $ts,
-        machine: { id: $mid, name: $mn, os: $os },
-        declarative: {
-          claude_md: $claude_md,
-          rules: $rules
-        },
-        procedural: {
-          skills: $skills,
-          agents: $agents,
-          output_styles: $output_styles
-        },
-        experiential: {
-          auto_memory: $auto_memory,
-          agent_memory: $agent_memory
-        },
-        environmental: {
-          settings: { content: $settings, hash: ("sha256:" + $settings_hash) },
-          keybindings: { content: $keybindings, hash: ("sha256:" + $keybindings_hash) },
-          mcp_servers: $mcp_servers
-        },
-        shared: {
-          skills: $shared_skills,
-          agents: $shared_agents,
-          rules: $shared_rules
-        }
-      }'
+  # Route large JSON vars through temp files to avoid ARG_MAX (macOS ~256KB).
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  printf '%s' "${claude_md:-null}"          > "$tmpdir/claude_md.json"
+  printf '%s' "${rules:-null}"              > "$tmpdir/rules.json"
+  printf '%s' "${skills:-null}"             > "$tmpdir/skills.json"
+  printf '%s' "${agents:-null}"             > "$tmpdir/agents.json"
+  printf '%s' "${output_styles:-null}"      > "$tmpdir/output_styles.json"
+  printf '%s' "${auto_memory:-null}"        > "$tmpdir/auto_memory.json"
+  printf '%s' "${agent_memory:-null}"       > "$tmpdir/agent_memory.json"
+  printf '%s' "${settings:-null}"           > "$tmpdir/settings.json"
+  printf '%s' "${keybindings:-null}"        > "$tmpdir/keybindings.json"
+  printf '%s' "${mcp_servers:-null}"        > "$tmpdir/mcp_servers.json"
+  printf '%s' "${shared_skills:-null}"      > "$tmpdir/shared_skills.json"
+  printf '%s' "${shared_agents:-null}"      > "$tmpdir/shared_agents.json"
+  printf '%s' "${shared_rules:-null}"       > "$tmpdir/shared_rules.json"
+
+  jq -n \
+    --arg schema_ver "1.0.0" \
+    --arg ts "$timestamp" \
+    --arg mid "$machine_id" \
+    --arg mn "$machine_name" \
+    --arg os "$os_type" \
+    --slurpfile claude_md     "$tmpdir/claude_md.json" \
+    --slurpfile rules         "$tmpdir/rules.json" \
+    --slurpfile skills        "$tmpdir/skills.json" \
+    --slurpfile agents        "$tmpdir/agents.json" \
+    --slurpfile output_styles "$tmpdir/output_styles.json" \
+    --slurpfile auto_memory   "$tmpdir/auto_memory.json" \
+    --slurpfile agent_memory  "$tmpdir/agent_memory.json" \
+    --slurpfile settings      "$tmpdir/settings.json" \
+    --arg settings_hash "${settings_hash}" \
+    --slurpfile keybindings   "$tmpdir/keybindings.json" \
+    --arg keybindings_hash "${keybindings_hash}" \
+    --slurpfile mcp_servers   "$tmpdir/mcp_servers.json" \
+    --slurpfile shared_skills "$tmpdir/shared_skills.json" \
+    --slurpfile shared_agents "$tmpdir/shared_agents.json" \
+    --slurpfile shared_rules  "$tmpdir/shared_rules.json" \
+    '{
+      schema_version: $schema_ver,
+      exported_at: $ts,
+      machine: { id: $mid, name: $mn, os: $os },
+      declarative: {
+        claude_md: $claude_md[0],
+        rules: $rules[0]
+      },
+      procedural: {
+        skills: $skills[0],
+        agents: $agents[0],
+        output_styles: $output_styles[0]
+      },
+      experiential: {
+        auto_memory: $auto_memory[0],
+        agent_memory: $agent_memory[0]
+      },
+      environmental: {
+        settings: { content: $settings[0], hash: ("sha256:" + $settings_hash) },
+        keybindings: { content: $keybindings[0], hash: ("sha256:" + $keybindings_hash) },
+        mcp_servers: $mcp_servers[0]
+      },
+      shared: {
+        skills: $shared_skills[0],
+        agents: $shared_agents[0],
+        rules: $shared_rules[0]
+      }
+    }'
+  rm -rf "$tmpdir"
 }
 
 # ── Main ───────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two unrelated macOS-specific bugs + one security leak that surface on first use with a non-trivial installation. All three were hit during a fresh \`/brain-init\` on macOS (Apple Silicon) with 26 skills and 5 per-project memory dirs.

### 1. \`decode_project_path\` returns empty string on BSD sed (`scripts/common.sh`)

The sed chain uses \`\\x00\` as a sentinel to protect doubled dashes during the dash→slash conversion. BSD sed (macOS default) doesn't accept that escape — emits \`sed: first RE may not be empty\`, non-zero exit. The pipeline silently returns empty string. Every \`project_name_from_encoded\` call returns \`""\`, so \`experiential.auto_memory\` ends up with a single \`""\` key and only one project's memory survives.

**Repro on a fresh macOS install:**
\`\`\`
$ /brain-init git@github.com:you/brain.git
$ jq '.experiential.auto_memory | keys' ~/.claude/brain-repo/consolidated/brain.json
[""]   # Should be ["project-a", "project-b", ...]
\`\`\`

**Fix:** replace the sed chain with bash parameter expansion — portable across BSD/GNU, and eliminates four subprocess spawns per call.

### 2. ARG_MAX overflow in \`build_snapshot\` (\`scripts/export.sh\`)

Passing large JSON blobs (26 skills with font/CSV assets) as \`--argjson\` arguments to \`jq -n\` blows past macOS \`ARG_MAX\` (~256 KB) → \`/usr/bin/jq: Argument list too long\` → export fails. Any user with the \`ui-styling\` or \`ai-artist\` skills will hit this on the first export.

**Fix:** route the large \`--argjson\` variables through temp files via \`--slurpfile\` + \`[0]\` indexing. Same output JSON, no arg-list bloat.

### 3. Silent \`.env\` leak in \`scan_dir_entries\` (\`scripts/export.sh\`)

\`scan_dir_entries\` used a bare \`find -type f\` which swept:
- Python venvs (\`~/.claude/skills/.venv\` = 81 MB of compiled \`.dylib\`/\`.so\`)
- \`node_modules/\`, \`__pycache__/\`
- **Dotfiles** — including \`~/.claude/skills/.env\`, which commonly holds API keys (e.g. \`GEMINI_API_KEY\` for the ai-multimodal skill).

The secret scanner warns on \`password:\`/\`secret:\` style lines, but doesn't recognize the \`KEY_NAME=AIza...\` form. So a \`.env\` with a Gemini key passes the scan and gets pushed to Git.

**Fix:** prune hidden directories (\`.venv\`, \`.git\`, \`.cache\`), \`node_modules\`, \`__pycache__\`, and \`venv\`; additionally exclude file-level \`.env\`, \`.pem\`, \`.key\` at the \`find\` level — defense in depth even if they somehow land in a non-pruned directory.

**Impact for existing users:** if anyone has run \`brain-init\` against a private repo with a \`.env\` file present, their key is in Git history. Suggest adding a release note recommending key rotation.

## Test plan

- [x] Fresh \`/brain-init\` on macOS (Apple Silicon) with 26 skills + 5 project memory dirs + \`.env\` in skills dir
  - Before: exports failed with ARG_MAX, or succeeded but leaked \`.env\` and had collapsed memory keys
  - After: export succeeds, snapshot is 28 MB (down from 90 MB after venv prune), no \`.env\` in snapshot, all 5 project memories correctly keyed
- [x] \`/brain-join\` on second macOS machine pulls + applies correctly, memory matches by project name
- [x] \`decode_project_path\` unit check against 5 real encoded paths returns correct basenames

🤖 Generated with [Claude Code](https://claude.com/claude-code)