### PR TITLE
fix(import): Windows / Git Bash compatibility

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -87,6 +87,17 @@ json_query() {
   jq -r "$filter"
 }
 
+# Run `jq -r <filter>` and strip any trailing CR.
+# Why: the Windows build of jq emits CRLF line terminators. `read -r` strips
+# the trailing \n but leaves the \r, so `$key` becomes "linting.md\r" and
+# subsequent `jq -r --arg k "$key" '.[$k].content'` lookups return empty.
+# No-op on Linux/macOS (input has no CR to strip).
+# Usage: echo "$json" | jq_lines '.foo // {} | keys[]' | while read -r x; do ...
+jq_lines() {
+  local filter="$1"
+  jq -r "$filter" | tr -d '\r'
+}
+
 json_build() {
   # Build JSON from arguments using jq
   # Usage: json_build --arg key value --arg key2 value2 'template'

--- a/scripts/import.sh
+++ b/scripts/import.sh
@@ -53,17 +53,35 @@ import_dir_entries() {
   fi
 
   # Resolve base_dir to absolute path for traversal check.
-  # Prefer `realpath -m` (forward-slash output across Git Bash + Linux + macOS).
-  # `python3 os.path.realpath` is used as a fallback only, because on Windows
-  # MinGW it misinterprets MSYS-style /c/Users/... paths as relative and
-  # returns C:\c\Users\... — which then fails the prefix check below and
-  # silently blocks every legitimate import.
-  local resolved_base
-  resolved_base=$(realpath -m "$base_dir" 2>/dev/null \
-    || echo "$base_dir" | python3 -c "import os,sys; print(os.path.realpath(sys.stdin.read().strip()))" 2>/dev/null \
-    || echo "$base_dir")
+  # Path-resolver preference and rationale:
+  #   1. GNU `realpath -m` — Git Bash and Linux ship it; produces forward-slash
+  #      output and supports paths whose tail doesn't yet exist (the first-time
+  #      import case).
+  #   2. `grealpath -m` — Homebrew coreutils on macOS installs GNU realpath under
+  #      this name; BSD `realpath` on stock macOS lacks `-m`, so we don't try it.
+  #   3. `python3 os.path.realpath` — last resort. Handles stock-macOS paths
+  #      fine but mangles MSYS-style /c/Users/... and /tmp/... on Windows MinGW
+  #      (returns C:\c\Users\...), which is what motivated the realpath-first
+  #      order in the first place.
+  # If all three fail we FAIL CLOSED: treat as unresolvable and refuse to write,
+  # rather than fall back to the raw "${base_dir}/${key}" string. The grep guard
+  # below already rejects literal `..` components, but resolver failure could
+  # still allow `..` in unusual encodings to sneak past the prefix check.
+  _resolve_path() {
+    local p="$1"
+    realpath -m "$p" 2>/dev/null \
+      || grealpath -m "$p" 2>/dev/null \
+      || echo "$p" | python3 -c "import os,sys; print(os.path.realpath(sys.stdin.read().strip()))" 2>/dev/null
+  }
 
-    echo "$json_entries" | jq -r 'keys[]' | tr -d '\r' | while read -r key; do
+  local resolved_base
+  resolved_base=$(_resolve_path "$base_dir")
+  if [ -z "$resolved_base" ]; then
+    log_warn "BLOCKED: could not resolve base directory '$base_dir' (install GNU coreutils or python3)"
+    return 0
+  fi
+
+    echo "$json_entries" | jq_lines 'keys[]' | while read -r key; do
       # Pure-bash path traversal guard: reject keys containing '..' components
       if echo "$key" | grep -qE '(^|/)\.\.(/|$)'; then
         log_warn "BLOCKED path traversal: $key"
@@ -72,9 +90,11 @@ import_dir_entries() {
 
       # PATH TRAVERSAL CHECK: ensure key doesn't escape base_dir
       local resolved_target
-      resolved_target=$(realpath -m "${resolved_base}/${key}" 2>/dev/null \
-        || echo "${resolved_base}/${key}" | python3 -c "import os,sys; print(os.path.realpath(sys.stdin.read().strip()))" 2>/dev/null \
-        || echo "${resolved_base}/${key}")
+      resolved_target=$(_resolve_path "${resolved_base}/${key}")
+      if [ -z "$resolved_target" ]; then
+        log_warn "BLOCKED: could not resolve target path for '$key'"
+        continue
+      fi
       if [[ "$resolved_target" != "${resolved_base}/"* ]]; then
         log_warn "BLOCKED path traversal attempt: ${key} (would write outside ${base_dir})"
         continue
@@ -97,7 +117,7 @@ validate_imports() {
 
 
   # Check for new/changed skills
-  echo "$brain" | jq -r '.procedural.skills // {} | keys[]' 2>/dev/null | tr -d '\r' | while read -r skill_path; do
+  echo "$brain" | jq_lines '.procedural.skills // {} | keys[]' 2>/dev/null | while read -r skill_path; do
     local target="${CLAUDE_DIR}/skills/${skill_path}"
     if [ ! -f "$target" ]; then
       log_warn "NEW skill will be imported: ${skill_path}"
@@ -114,7 +134,7 @@ validate_imports() {
   done
 
   # Check for new/changed agents
-  echo "$brain" | jq -r '.procedural.agents // {} | keys[]' 2>/dev/null | tr -d '\r' | while read -r agent_path; do
+  echo "$brain" | jq_lines '.procedural.agents // {} | keys[]' 2>/dev/null | while read -r agent_path; do
     local target="${CLAUDE_DIR}/agents/${agent_path}"
     if [ ! -f "$target" ]; then
       log_warn "NEW agent will be imported: ${agent_path}"
@@ -131,7 +151,7 @@ validate_imports() {
   done
 
   # Check for new/changed rules
-  echo "$brain" | jq -r '.declarative.rules // {} | keys[]' 2>/dev/null | tr -d '\r' | while read -r rule_path; do
+  echo "$brain" | jq_lines '.declarative.rules // {} | keys[]' 2>/dev/null | while read -r rule_path; do
     local target="${CLAUDE_DIR}/rules/${rule_path}"
     if [ ! -f "$target" ]; then
       log_warn "NEW rule will be imported: ${rule_path}"
@@ -193,7 +213,7 @@ import_brain() {
     import_dir_entries "${CLAUDE_DIR}/output-styles" "$output_styles"
 
   # Experiential: auto memory
-    echo "$brain" | jq -r '.experiential.auto_memory // {} | keys[]' 2>/dev/null | tr -d '\r' | while read -r project; do
+    echo "$brain" | jq_lines '.experiential.auto_memory // {} | keys[]' 2>/dev/null | while read -r project; do
       local entries
       entries=$(echo "$brain" | jq --arg p "$project" '.experiential.auto_memory[$p] // {}')
       # Find matching project dir
@@ -214,7 +234,7 @@ import_brain() {
     done
 
   # Experiential: agent memory
-    echo "$brain" | jq -r '.experiential.agent_memory // {} | keys[]' 2>/dev/null | tr -d '\r' | while read -r agent; do
+    echo "$brain" | jq_lines '.experiential.agent_memory // {} | keys[]' 2>/dev/null | while read -r agent; do
       # Sanitize agent name: block path traversal
       if echo "$agent" | grep -qE '(\.\.|/)'; then
         log_warn "BLOCKED suspicious agent name: ${agent}"

--- a/scripts/import.sh
+++ b/scripts/import.sh
@@ -52,11 +52,18 @@ import_dir_entries() {
     return 0
   fi
 
-  # Resolve base_dir to absolute path for traversal check (pipe through stdin to avoid injection)
+  # Resolve base_dir to absolute path for traversal check.
+  # Prefer `realpath -m` (forward-slash output across Git Bash + Linux + macOS).
+  # `python3 os.path.realpath` is used as a fallback only, because on Windows
+  # MinGW it misinterprets MSYS-style /c/Users/... paths as relative and
+  # returns C:\c\Users\... — which then fails the prefix check below and
+  # silently blocks every legitimate import.
   local resolved_base
-  resolved_base=$(echo "$base_dir" | python3 -c "import os,sys; print(os.path.realpath(sys.stdin.read().strip()))" 2>/dev/null || realpath "$base_dir" 2>/dev/null || echo "$base_dir")
+  resolved_base=$(realpath -m "$base_dir" 2>/dev/null \
+    || echo "$base_dir" | python3 -c "import os,sys; print(os.path.realpath(sys.stdin.read().strip()))" 2>/dev/null \
+    || echo "$base_dir")
 
-    echo "$json_entries" | jq -r 'keys[]' | while read -r key; do
+    echo "$json_entries" | jq -r 'keys[]' | tr -d '\r' | while read -r key; do
       # Pure-bash path traversal guard: reject keys containing '..' components
       if echo "$key" | grep -qE '(^|/)\.\.(/|$)'; then
         log_warn "BLOCKED path traversal: $key"
@@ -65,7 +72,9 @@ import_dir_entries() {
 
       # PATH TRAVERSAL CHECK: ensure key doesn't escape base_dir
       local resolved_target
-      resolved_target=$(echo "$resolved_base/$key" | python3 -c "import os,sys; print(os.path.realpath(sys.stdin.read().strip()))" 2>/dev/null || realpath "${resolved_base}/${key}" 2>/dev/null || echo "${resolved_base}/${key}")
+      resolved_target=$(realpath -m "${resolved_base}/${key}" 2>/dev/null \
+        || echo "${resolved_base}/${key}" | python3 -c "import os,sys; print(os.path.realpath(sys.stdin.read().strip()))" 2>/dev/null \
+        || echo "${resolved_base}/${key}")
       if [[ "$resolved_target" != "${resolved_base}/"* ]]; then
         log_warn "BLOCKED path traversal attempt: ${key} (would write outside ${base_dir})"
         continue
@@ -88,7 +97,7 @@ validate_imports() {
 
 
   # Check for new/changed skills
-  echo "$brain" | jq -r '.procedural.skills // {} | keys[]' 2>/dev/null | while read -r skill_path; do
+  echo "$brain" | jq -r '.procedural.skills // {} | keys[]' 2>/dev/null | tr -d '\r' | while read -r skill_path; do
     local target="${CLAUDE_DIR}/skills/${skill_path}"
     if [ ! -f "$target" ]; then
       log_warn "NEW skill will be imported: ${skill_path}"
@@ -105,7 +114,7 @@ validate_imports() {
   done
 
   # Check for new/changed agents
-  echo "$brain" | jq -r '.procedural.agents // {} | keys[]' 2>/dev/null | while read -r agent_path; do
+  echo "$brain" | jq -r '.procedural.agents // {} | keys[]' 2>/dev/null | tr -d '\r' | while read -r agent_path; do
     local target="${CLAUDE_DIR}/agents/${agent_path}"
     if [ ! -f "$target" ]; then
       log_warn "NEW agent will be imported: ${agent_path}"
@@ -122,7 +131,7 @@ validate_imports() {
   done
 
   # Check for new/changed rules
-  echo "$brain" | jq -r '.declarative.rules // {} | keys[]' 2>/dev/null | while read -r rule_path; do
+  echo "$brain" | jq -r '.declarative.rules // {} | keys[]' 2>/dev/null | tr -d '\r' | while read -r rule_path; do
     local target="${CLAUDE_DIR}/rules/${rule_path}"
     if [ ! -f "$target" ]; then
       log_warn "NEW rule will be imported: ${rule_path}"
@@ -184,7 +193,7 @@ import_brain() {
     import_dir_entries "${CLAUDE_DIR}/output-styles" "$output_styles"
 
   # Experiential: auto memory
-    echo "$brain" | jq -r '.experiential.auto_memory // {} | keys[]' 2>/dev/null | while read -r project; do
+    echo "$brain" | jq -r '.experiential.auto_memory // {} | keys[]' 2>/dev/null | tr -d '\r' | while read -r project; do
       local entries
       entries=$(echo "$brain" | jq --arg p "$project" '.experiential.auto_memory[$p] // {}')
       # Find matching project dir
@@ -205,7 +214,7 @@ import_brain() {
     done
 
   # Experiential: agent memory
-    echo "$brain" | jq -r '.experiential.agent_memory // {} | keys[]' 2>/dev/null | while read -r agent; do
+    echo "$brain" | jq -r '.experiential.agent_memory // {} | keys[]' 2>/dev/null | tr -d '\r' | while read -r agent; do
       # Sanitize agent name: block path traversal
       if echo "$agent" | grep -qE '(\.\.|/)'; then
         log_warn "BLOCKED suspicious agent name: ${agent}"

--- a/scripts/merge-semantic.sh
+++ b/scripts/merge-semantic.sh
@@ -207,7 +207,7 @@ fi
 # Update memory entries
 if [ "$(echo "$merged_memory" | jq 'length')" -gt 0 ]; then
   tmp=$(brain_mktemp)
-  echo "$merged_memory" | jq -r 'keys[]' | while read -r project; do
+  echo "$merged_memory" | jq -r 'keys[]' | tr -d '\r' | while read -r project; do
     content=$(echo "$merged_memory" | jq -r --arg p "$project" '.[$p]')
     jq --arg p "$project" --arg c "$content" \
       '.experiential.auto_memory[$p]["MEMORY.md"].content = $c | .experiential.auto_memory[$p]["MEMORY.md"].hash = "merged"' \

--- a/scripts/merge-semantic.sh
+++ b/scripts/merge-semantic.sh
@@ -207,7 +207,7 @@ fi
 # Update memory entries
 if [ "$(echo "$merged_memory" | jq 'length')" -gt 0 ]; then
   tmp=$(brain_mktemp)
-  echo "$merged_memory" | jq -r 'keys[]' | tr -d '\r' | while read -r project; do
+  echo "$merged_memory" | jq_lines 'keys[]' | while read -r project; do
     content=$(echo "$merged_memory" | jq -r --arg p "$project" '.[$p]')
     jq --arg p "$project" --arg c "$content" \
       '.experiential.auto_memory[$p]["MEMORY.md"].content = $c | .experiential.auto_memory[$p]["MEMORY.md"].hash = "merged"' \


### PR DESCRIPTION
## Summary

Two issues prevent any skill, agent, rule, or memory file from importing on Windows under Git Bash. Three existing tests fail on `main` on Windows:

- `test_export_import_roundtrip`: *Rules not imported*
- `test_export_import_roundtrip`: *Skills directory not created*
- `test_shared_namespace`: *Shared skill not imported*

This patch turns them green. **41/44 → 44/44** on Windows; **Linux/macOS unchanged**.

## The two bugs

### 1. Path-traversal guard uses `python3 os.path.realpath` first

`scripts/import.sh:57,68` runs:

```bash
resolved_base=$(echo "$base_dir" | python3 -c "import os,sys; print(os.path.realpath(sys.stdin.read().strip()))" 2>/dev/null || realpath "$base_dir" 2>/dev/null || echo "$base_dir")
```

On Windows MinGW, `python3` interprets MSYS paths (`/c/Users/...`, `/tmp/...`) as **relative** and returns `C:\c\Users\...` / `C:\tmp\...`. The subsequent prefix check `[[ "$resolved_target" != "${resolved_base}/"* ]]` then fails for every key and silently BLOCKs the write.

**Fix:** prefer `realpath -m` (GNU coreutils, forward-slash output across Git Bash + Linux + macOS; `-m` allows paths whose tail doesn't exist yet — exactly the first-time-import case). Keep `python3` as a fallback for systems where `realpath` isn't available.

### 2. `jq -r 'keys[]' | while read -r key` carries trailing `\r`

The Windows build of jq writes CRLF line terminators. `read -r` strips the trailing `\n` but leaves the `\r`, so `$key` becomes `linting.md\r`. The follow-up `jq -r --arg k "$key" '.[$k].content // empty'` looks up `\"linting.md\r\"` in a JSON object whose actual key is `\"linting.md\"`, gets nothing, and `write_if_changed` returns early on the empty content. No error, no log line — entries just vanish.

Reproducer:
```console
$ echo '{\"a\":1}' | jq -r 'keys[]' | od -c | head -1
0000000   a  \r  \n
```

**Fix:** pipe through `tr -d '\r'` between `jq` and `read` in all six loops in `import.sh` plus the one in `merge-semantic.sh`. No-op on Linux/macOS (no `\r` to strip).

## Why these two together

Both are Windows-only blockers in the same import path; together they convert \"no skills/rules/memory ever sync to Windows\" into working bi-directional sync. Splitting them would just produce two PRs that each look like they fix the Windows tests but actually only one of them does. Keeping them in one focused commit.

## Test plan

- [x] `bash tests/run-tests.sh` on Windows 11 / Git Bash (MINGW64): 44 passed, 0 failed
- [x] Verified `test_path_traversal_blocked` still passes (the `..` pre-check fires before the realpath logic, so the security property is preserved)
- [ ] CI / cross-OS verification (recommend running on Linux + macOS before merge — local Linux/macOS sandbox not available to me)

## Environment

- Windows 11 Pro 10.0.26100
- Shell: Git Bash (MINGW64)
- jq 1.8.1, GNU coreutils realpath 8.32, Python 3.12.10
- Hit while joining a brain network with `/claude-brain-sync:brain-join` — every skill/agent/rule from the MacBook silently disappeared