### PR TITLE
fix(import): handle keybindings.json shape mismatch without crashing

### DIFF
--- a/scripts/import.sh
+++ b/scripts/import.sh
@@ -297,14 +297,20 @@ import_brain() {
           log_info "Updated: keybindings.json (merged)"
         elif [ "$remote_kb_type" = "array" ] && [ "$local_kb_type" != "array" ]; then
           # Local is empty-object / unexpected shape; remote has real bindings — adopt remote.
-          echo "$new_keybindings" > "${CLAUDE_DIR}/keybindings.json"
+          local tmp
+          tmp=$(brain_mktemp)
+          printf '%s\n' "$new_keybindings" > "$tmp"
+          mv "$tmp" "${CLAUDE_DIR}/keybindings.json"
           log_info "Updated: keybindings.json (replaced — local was $local_kb_type)"
         else
           # Either remote is empty/non-array, or both are non-arrays. Nothing to merge.
           log_info "Skipped keybindings merge (local=$local_kb_type, remote=$remote_kb_type)"
         fi
       else
-        echo "$new_keybindings" > "${CLAUDE_DIR}/keybindings.json"
+        local tmp
+        tmp=$(brain_mktemp)
+        printf '%s\n' "$new_keybindings" > "$tmp"
+        mv "$tmp" "${CLAUDE_DIR}/keybindings.json"
         log_info "Created: keybindings.json"
       fi
     fi

--- a/scripts/import.sh
+++ b/scripts/import.sh
@@ -272,18 +272,37 @@ import_brain() {
     fi
 
   # Environmental: keybindings (union)
+  # Claude Code may write keybindings.json as either an array `[{key,command,…}]`
+  # or as an empty object `{}` (no bindings configured). The union-merge below
+  # uses `unique_by`, which requires both inputs to be arrays — otherwise jq
+  # aborts with "object ({}) and array ([]) cannot be sorted, as they are not
+  # both arrays" and `set -euo pipefail` kills the rest of import_brain.
+  # Detect the shape on both sides and skip / use-as-is in non-array cases.
     local new_keybindings
     new_keybindings=$(echo "$brain" | jq '.environmental.keybindings.content // null')
     if [ "$new_keybindings" != "null" ]; then
+      local remote_kb_type
+      remote_kb_type=$(echo "$new_keybindings" | jq -r 'type' 2>/dev/null || echo "null")
       if [ -f "${CLAUDE_DIR}/keybindings.json" ]; then
-        local tmp tmp_remote_kb
-        tmp=$(brain_mktemp)
-        tmp_remote_kb=$(brain_mktemp)
-        printf '%s\n' "$new_keybindings" > "$tmp_remote_kb"
-        # Union keybindings arrays (deduplicate by key+command)
-        jq -s '.[0] + .[1] | unique_by(.key, .command)' "${CLAUDE_DIR}/keybindings.json" "$tmp_remote_kb" > "$tmp"
-        mv "$tmp" "${CLAUDE_DIR}/keybindings.json"
-        log_info "Updated: keybindings.json (merged)"
+        local local_kb_type
+        local_kb_type=$(jq -r 'type' "${CLAUDE_DIR}/keybindings.json" 2>/dev/null || echo "null")
+        if [ "$local_kb_type" = "array" ] && [ "$remote_kb_type" = "array" ]; then
+          local tmp tmp_remote_kb
+          tmp=$(brain_mktemp)
+          tmp_remote_kb=$(brain_mktemp)
+          printf '%s\n' "$new_keybindings" > "$tmp_remote_kb"
+          # Union keybindings arrays (deduplicate by key+command)
+          jq -s '.[0] + .[1] | unique_by(.key, .command)' "${CLAUDE_DIR}/keybindings.json" "$tmp_remote_kb" > "$tmp"
+          mv "$tmp" "${CLAUDE_DIR}/keybindings.json"
+          log_info "Updated: keybindings.json (merged)"
+        elif [ "$remote_kb_type" = "array" ] && [ "$local_kb_type" != "array" ]; then
+          # Local is empty-object / unexpected shape; remote has real bindings — adopt remote.
+          echo "$new_keybindings" > "${CLAUDE_DIR}/keybindings.json"
+          log_info "Updated: keybindings.json (replaced — local was $local_kb_type)"
+        else
+          # Either remote is empty/non-array, or both are non-arrays. Nothing to merge.
+          log_info "Skipped keybindings merge (local=$local_kb_type, remote=$remote_kb_type)"
+        fi
       else
         echo "$new_keybindings" > "${CLAUDE_DIR}/keybindings.json"
         log_info "Created: keybindings.json"

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -793,6 +793,56 @@ test_register_machine_preserves_timestamps() {
     || fail "last_push should be null on fresh registration (got '$actual_push')"
 }
 
+test_keybindings_shape_mismatch() {
+  section "Import: keybindings.json shape mismatch tolerated"
+
+  # Build a minimal brain whose env.keybindings.content is an empty object {}.
+  # Claude Code writes this when no keybindings are configured. The pre-fix
+  # union-merge used `jq unique_by` which requires arrays — it would crash with
+  # "object ({}) and array ([]) cannot be sorted", and because import.sh runs
+  # under `set -euo pipefail` the crash kills the rest of import_brain (e.g.
+  # the shared-namespace import that follows).
+  cat > "$TEST_DIR/kb-brain.json" <<'EOF'
+{
+  "schema_version": "1.0.0",
+  "machine": {"id":"t","name":"t","os":"linux"},
+  "declarative": {"claude_md": null, "rules": {}},
+  "procedural": {"skills": {}, "agents": {}, "output_styles": {}},
+  "experiential": {"auto_memory": {}, "agent_memory": {}},
+  "environmental": {
+    "settings": {"content": null, "hash": ""},
+    "keybindings": {"content": {}, "hash": ""},
+    "mcp_servers": {}
+  },
+  "shared": {
+    "skills": {"shared-sentinel.md": {"content": "# sentinel", "hash": "sha256:1"}},
+    "agents": {}, "rules": {}
+  }
+}
+EOF
+
+  # Force local keybindings.json to also be {} (the bug's worst case)
+  echo '{}' > "$CLAUDE_DIR/keybindings.json"
+
+  local output
+  output=$(bash "$PROJECT_DIR/scripts/import.sh" "$TEST_DIR/kb-brain.json" --no-backup 2>&1) || true
+
+  if echo "$output" | grep -qi "object.*and array.*cannot be sorted"; then
+    fail "keybindings merge still crashes on object shape"
+  else
+    pass "keybindings merge handled object shape without crashing"
+  fi
+
+  # The keybindings step is followed by the shared-namespace import and a final
+  # "Brain import complete." log line. If the crash propagated through `set -e`,
+  # that line never prints. Assert we made it past keybindings.
+  if echo "$output" | grep -q "Brain import complete"; then
+    pass "import continued past keybindings step ('Brain import complete' logged)"
+  else
+    fail "import aborted at keybindings step — 'Brain import complete' missing"
+  fi
+}
+
 # ── Run ────────────────────────────────────────────────────────────────────────
 echo -e "${CYAN}claude-brain integration tests${NC}"
 echo "================================"
@@ -820,6 +870,7 @@ test_export_scans_all_file_types
 test_semantic_merge_fallback
 test_wsl_detection
 test_encryption_roundtrip
+test_keybindings_shape_mismatch
 
 echo ""
 echo "================================"

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -827,20 +827,23 @@ EOF
   local output
   output=$(bash "$PROJECT_DIR/scripts/import.sh" "$TEST_DIR/kb-brain.json" --no-backup 2>&1) || true
 
+  # When the bug fires, both assertions below would fail (crash detected AND
+  # `Brain import complete.` missing). Return on the first failure so the test
+  # reports one clear root cause per run instead of two correlated failures.
   if echo "$output" | grep -qi "object.*and array.*cannot be sorted"; then
     fail "keybindings merge still crashes on object shape"
-  else
-    pass "keybindings merge handled object shape without crashing"
+    return
   fi
+  pass "keybindings merge handled object shape without crashing"
 
   # The keybindings step is followed by the shared-namespace import and a final
   # "Brain import complete." log line. If the crash propagated through `set -e`,
   # that line never prints. Assert we made it past keybindings.
-  if echo "$output" | grep -q "Brain import complete"; then
-    pass "import continued past keybindings step ('Brain import complete' logged)"
-  else
+  if ! echo "$output" | grep -q "Brain import complete"; then
     fail "import aborted at keybindings step — 'Brain import complete' missing"
+    return
   fi
+  pass "import continued past keybindings step ('Brain import complete' logged)"
 }
 
 # ── Run ────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`scripts/import.sh` merges remote keybindings into local with:

```bash
jq -s '.[0] + .[1] | unique_by(.key, .command)' \
    "${CLAUDE_DIR}/keybindings.json" "$tmp_remote_kb" > "$tmp"
```

`unique_by` requires both inputs to be arrays. But Claude Code can legitimately write `keybindings.json` as an empty object `{}` (the "no bindings configured" state). When that happens — local `{}` or remote `{}` — jq exits with:

```
jq: error (at /tmp/tmp.XXX:1): object ({}) and array ([]) cannot be sorted, as they are not both arrays
```

Because `import.sh` runs under `set -euo pipefail`, this **kills the rest of `import_brain` mid-way**. The shared-namespace import that follows the keybindings step and the final `"Brain import complete."` marker never run. From the user's side the import looks like it succeeded (CLAUDE.md, settings, MCP servers, agents, skills all landed before this point), but anything after keybindings silently drops on the floor.

I hit this during `/claude-brain-sync:brain-join` joining from a fresh Windows machine where both ends happened to be `{}`.

## Fix

Detect the shape on both sides before merging:

| Local | Remote | Behavior |
|-------|--------|----------|
| array | array | union via `unique_by` (existing behavior) |
| non-array | array | adopt remote (replace empty/unexpected local) |
| any | non-array | log and skip — nothing to merge |

No more crash; the import always runs to completion.

## Test

Added `test_keybindings_shape_mismatch` that:
1. Builds a brain whose `environmental.keybindings.content` is `{}`
2. Seeds local `keybindings.json` as `{}` too (the worst case)
3. Asserts the import does not emit the `"object and array cannot be sorted"` jq error
4. Asserts `"Brain import complete."` still appears in the log — proof the rest of `import_brain` runs

Without the fix the new test fails:
```
✗ keybindings merge still crashes on object shape
✗ import aborted at keybindings step — 'Brain import complete' missing
```

With the fix:
```
✓ keybindings merge handled object shape without crashing
✓ import continued past keybindings step ('Brain import complete' logged)
```

## Test plan

- [x] `bash tests/run-tests.sh` — new test passes, existing tests unaffected
- [x] Verified the new test fails on unpatched `main`
- [ ] Cross-OS verification on CI

## Relation to other PRs

Independent of #43 (Windows compat). This bug can fire on any OS — the trigger is just both keybindings ends being `{}`, which happens on a fresh install where neither side has configured custom bindings yet. PR #21 mentioned a similar issue from a different angle (bindings stored as `{"bindings":[...]}`); this PR targets the empty-object case, which is the more common Claude Code default.