### PR TITLE
fix(export): scrub nested .env and Authorization headers from snapshot

### DIFF
--- a/scripts/export.sh
+++ b/scripts/export.sh
@@ -161,9 +161,20 @@ build_snapshot() {
   fi
 
   # Environmental: settings (strip env vars — mcpServers live in ~/.claude.json, not here)
+  # SECURITY: top-level `.env` is the obvious case, but plugin configs nest their
+  # own env blocks (e.g. `.pluginConfig.<plugin>.env`) that commonly hold API
+  # tokens. Also strip Authorization headers anywhere in the tree. Use `walk` so
+  # we catch arbitrary depth/structure, current or future.
   local settings="null"
   if ! $MEMORY_ONLY && [ -f "${CLAUDE_DIR}/settings.json" ]; then
-    settings=$(jq 'del(.env)' "${CLAUDE_DIR}/settings.json")
+    settings=$(jq '
+      walk(
+        if type == "object" then
+          del(.env)
+          | (if has("headers") then .headers |= del(.Authorization) else . end)
+        else . end
+      )
+    ' "${CLAUDE_DIR}/settings.json")
   fi
 
   local settings_hash="null"
@@ -182,13 +193,17 @@ build_snapshot() {
   # Environmental: MCP servers (from ~/.claude.json, NOT settings.json)
   # Claude Code stores mcpServers in ~/.claude.json (CLAUDE_JSON),
   # while settings.json only contains MCP policy fields.
-  # SECURITY: Strip env fields from each server config (may contain API keys/tokens)
+  # SECURITY: strip both env (stdio/proc servers' API keys) AND the Authorization
+  # header (HTTP/SSE servers like Figma store their bearer token there).
   local mcp_servers="{}"
   if ! $MEMORY_ONLY && [ -f "${CLAUDE_JSON}" ]; then
     mcp_servers=$(jq '
       .mcpServers // {} |
       to_entries |
-      map(.value = (.value | del(.env))) |
+      map(.value = (.value
+        | del(.env)
+        | (if has("headers") then .headers |= del(.Authorization) else . end)
+      )) |
       from_entries
     ' "${CLAUDE_JSON}" 2>/dev/null || echo "{}")
     # Rewrite absolute home paths to ${HOME}

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -161,6 +161,9 @@ EOF
 EOF
 
   # Settings
+  # Includes a top-level env (existing test_export_no_secrets) AND a nested
+  # pluginConfig.<plugin>.env block holding a github-PAT-shaped token, to
+  # exercise the recursive scrub for nested secret containers.
   cat > "$CLAUDE_DIR/settings.json" <<'EOF'
 {
   "permissions": {
@@ -172,6 +175,13 @@ EOF
   },
   "env": {
     "SECRET_KEY": "should-not-be-exported"
+  },
+  "pluginConfig": {
+    "github@claude-plugins-official": {
+      "env": {
+        "GITHUB_TOKEN": "ghp_FAKE_should_not_be_exported_FAKE_FAKE_FAKE"
+      }
+    }
   }
 }
 EOF
@@ -180,6 +190,31 @@ EOF
   cat > "$CLAUDE_DIR/keybindings.json" <<'EOF'
 [{"key": "ctrl+k", "command": "clear", "context": "terminal"}]
 EOF
+
+  # ~/.claude.json — Claude Code stores mcpServers here. Include both an env-bearing
+  # stdio server and an HTTP server with an Authorization Bearer header so the export
+  # scrubber gets exercised on both shapes.
+  cat > "$HOME/.claude.json" <<'EOF'
+{
+  "mcpServers": {
+    "stdio-server": {
+      "command": "/usr/bin/some-mcp",
+      "env": {
+        "API_KEY": "key-FAKE_stdio_should_not_be_exported_FAKE"
+      }
+    },
+    "figma": {
+      "type": "http",
+      "url": "https://mcp.figma.com/mcp",
+      "headers": {
+        "Authorization": "Bearer figd_FAKE_should_not_be_exported_FAKE_FAKE",
+        "X-Other-Header": "kept"
+      }
+    }
+  }
+}
+EOF
+  export CLAUDE_JSON="$HOME/.claude.json"
 
   # Init brain-repo as git repo
   (cd "$BRAIN_REPO" && git init -q -b main && git config user.email "test@test.com" && git config user.name "Test" && echo '{"entries":[]}' > meta/merge-log.json && git add -A && git commit -q -m "init")
@@ -245,9 +280,9 @@ test_export_no_secrets() {
   local content
   content=$(cat "$output")
 
-  # Env vars should not appear
+  # Env vars should not appear (top-level settings.env)
   if echo "$content" | grep -q "should-not-be-exported"; then
-    fail "Env var SECRET_KEY leaked into snapshot"
+    fail "Secret marker 'should-not-be-exported' leaked into snapshot"
   else
     pass "Env vars excluded from snapshot"
   fi
@@ -259,6 +294,42 @@ test_export_no_secrets() {
     pass "settings.env stripped from snapshot"
   else
     fail "settings.env present in snapshot: $env_val"
+  fi
+
+  # settings.pluginConfig.<plugin>.env should also be stripped (nested env)
+  local nested_token
+  nested_token=$(jqr '.environmental.settings.content.pluginConfig["github@claude-plugins-official"].env.GITHUB_TOKEN' "$output" 2>/dev/null || echo "null")
+  if [ "$nested_token" = "null" ] || [ -z "$nested_token" ]; then
+    pass "Nested settings.pluginConfig.*.env stripped from snapshot"
+  else
+    fail "Nested env leaked into snapshot: $nested_token"
+  fi
+
+  # mcpServers.<server>.env should be stripped (existing protection)
+  local mcp_env
+  mcp_env=$(jqr '.environmental.mcp_servers["stdio-server"].env' "$output" 2>/dev/null || echo "null")
+  if [ "$mcp_env" = "null" ] || [ -z "$mcp_env" ]; then
+    pass "mcp_servers.*.env stripped from snapshot"
+  else
+    fail "mcp_servers.*.env leaked into snapshot: $mcp_env"
+  fi
+
+  # mcpServers.<server>.headers.Authorization should be stripped (NEW)
+  local mcp_auth
+  mcp_auth=$(jqr '.environmental.mcp_servers.figma.headers.Authorization' "$output" 2>/dev/null || echo "null")
+  if [ "$mcp_auth" = "null" ] || [ -z "$mcp_auth" ]; then
+    pass "mcp_servers.*.headers.Authorization stripped from snapshot"
+  else
+    fail "mcp_servers.*.headers.Authorization leaked into snapshot: $mcp_auth"
+  fi
+
+  # Non-Authorization headers should be preserved (regression guard)
+  local kept_header
+  kept_header=$(jqr '.environmental.mcp_servers.figma.headers["X-Other-Header"]' "$output" 2>/dev/null || echo "null")
+  if [ "$kept_header" = "kept" ]; then
+    pass "Non-Authorization MCP headers preserved"
+  else
+    fail "Non-Authorization MCP header lost (got '$kept_header')"
   fi
 }
 


### PR DESCRIPTION
## Summary

The brain snapshot pushed to the Git remote is supposed to be free of plain-text credentials. Two real-world token locations slip through the current redaction in `scripts/export.sh`:

1. **settings.json** — `del(.env)` only strips the top-level env. Plugin configs nest their own env blocks underneath, e.g. `.pluginConfig.github@claude-plugins-official.env.GITHUB_TOKEN`. Those nested env blocks land in the snapshot in the clear.

2. **~/.claude.json** — `del(.env)` is applied to each MCP server, which covers stdio/proc servers that read tokens from env. HTTP/SSE servers (e.g. the Figma MCP) instead carry their bearer token in `.headers.Authorization`. That path is currently untouched.

Both were observed during `/claude-brain-sync:brain-join`. The bundled `scan_for_secrets` correctly flagged `ghp_…` and `Bearer figd_…` in the snapshot; without a manual scrub they'd have been committed to the brain remote.

> **Process note:** [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#reporting-security-issues) instructs reporters to use GitHub's [private vulnerability reporting](https://github.com/toroleapinc/claude-brain/security/advisories/new) for security issues. That feature is currently **disabled** on this repo (`gh api repos/toroleapinc/claude-brain/private-vulnerability-reporting` → `{\"enabled\":false}`), so a public PR is the only path I had. Worth enabling via *Settings → Code security → Private vulnerability reporting* for future reports.

Severity is moderate — leaked tokens flow only to a remote the user configured themselves (typically their own private brain repo), not to an untrusted attacker — but they'd then be detectable by GitHub's secret scanner, get auto-revoked, and possibly trigger pager noise.

## Fix

`scripts/export.sh`:

- **settings.json** — replace `jq 'del(.env)'` with a `walk` filter that strips `.env` *and* `.headers.Authorization` at every depth. `walk` is used (rather than a list of known paths) so future plugin configs are covered automatically.
- **mcpServers** — extend the existing `del(.env)` to also strip `.headers.Authorization`. Other headers (e.g. `Content-Type`) are preserved.

## Tests

Extended the existing `setup_sandbox` fixture with:

- `.pluginConfig.github@claude-plugins-official.env.GITHUB_TOKEN` in `settings.json` (nested-env path)
- A `~/.claude.json` fixture containing one stdio server with `.env` and one HTTP server with `.headers.Authorization` plus a non-secret header

Extended `test_export_no_secrets` with assertions for:

- nested `settings.pluginConfig.*.env` stripped ✓
- `mcpServers.*.env` stripped (existing protection — now actually exercised) ✓
- `mcpServers.*.headers.Authorization` stripped ✓
- `mcpServers.*.headers` (non-Authorization) preserved ✓ (regression guard)

Without the patch, the two new \"stripped\" assertions fail with the fake tokens visibly leaked:

```
✗ Nested env leaked into snapshot: ghp_FAKE_should_not_be_exported_FAKE_FAKE_FAKE
✗ mcp_servers.*.headers.Authorization leaked into snapshot: Bearer figd_FAKE_should_not_be_exported_FAKE_FAKE
```

With the patch:

```
✓ Nested settings.pluginConfig.*.env stripped from snapshot
✓ mcp_servers.*.headers.Authorization stripped from snapshot
✓ Non-Authorization MCP headers preserved
```

## Test plan

- [x] `bash tests/run-tests.sh` — 45/45 pass on the test-touched paths
- [x] Confirmed the new assertions fail on unpatched `main`
- [ ] CI / cross-OS verification

## Relation to other PRs

Independent of #43 (Windows compat) and #44 (keybindings shape). Each PR addresses a separate root cause; this one is the export-side scrubber.