### PR TITLE
fix(sync): close SessionStart fork bomb, keep OAuth working, idempotent fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to claude-brain will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **`SessionStart`-hook fork bomb during sync.** The headless `claude -p` call inside `merge-semantic.sh`/`evolve.sh` re-ran the brain-sync `SessionStart` hook in the child process, which started another `pull.sh → merge-semantic.sh → claude -p` chain — spawning a new process every few seconds (30+ runaway processes within minutes). Fixed with a `BRAIN_SYNC_ACTIVE` env-var sentinel: `pull.sh`/`push.sh` export it and exit early if already set, `evolve.sh`/`merge-semantic.sh` export it defensively at their `claude -p` spawn site, and the `SessionStart`/`SessionEnd`/`PreCompact` hooks skip when it is set. The flag is inherited by the `claude -p` child, so its hook no-ops instead of recursing.
+- **OAuth auth broke during semantic merge.** An earlier fix used `--bare` on the `claude -p` call to stop the fork bomb, but `--bare` also disables keychain reads — so users authenticated via Claude.ai OAuth (rather than `ANTHROPIC_API_KEY`) saw every semantic merge fail with "Not logged in" and fall back to concatenation. `--bare` is replaced by the env-var guard above, restoring OAuth keychain access.
+- **Idempotent concatenation fallback.** When the semantic merge fell back to concatenation, it appended an "Unmerged content" marker block on every run without stripping pre-existing ones — so `CLAUDE.md` grew by one duplicate copy per sync (observed accumulating identical copies across repeated syncs in the wild). The fallback now strips prior marker sections from both base and incoming snapshots before re-appending, so repeated runs converge.
+
+### Changed
+- Headless `claude -p` merge/evolve calls now pass `--no-session-persistence` so these one-shot calls leave no entry in the Claude Code session picker.
+
 ## [0.2.0] - 2026-05-07
 
 ### Fixed

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if [ -f \"${HOME}/.claude/brain-config.json\" ]; then bash \"${CLAUDE_PLUGIN_ROOT}/scripts/pull.sh\" --quiet --auto-merge; fi",
+            "command": "if [ -z \"${BRAIN_SYNC_ACTIVE:-}\" ] && [ -f \"${HOME}/.claude/brain-config.json\" ]; then bash \"${CLAUDE_PLUGIN_ROOT}/scripts/pull.sh\" --quiet --auto-merge; fi",
             "timeout": 30,
             "async": true,
             "statusMessage": "Syncing brain..."
@@ -20,7 +20,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if [ -f \"${HOME}/.claude/brain-config.json\" ]; then bash \"${CLAUDE_PLUGIN_ROOT}/scripts/push.sh\" --quiet || true; fi",
+            "command": "if [ -z \"${BRAIN_SYNC_ACTIVE:-}\" ] && [ -f \"${HOME}/.claude/brain-config.json\" ]; then bash \"${CLAUDE_PLUGIN_ROOT}/scripts/push.sh\" --quiet || true; fi",
             "timeout": 15,
             "async": true,
             "statusMessage": "Saving brain..."
@@ -34,7 +34,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if [ -f \"${HOME}/.claude/brain-config.json\" ]; then bash \"${CLAUDE_PLUGIN_ROOT}/scripts/export.sh\" --memory-only --quiet > /dev/null; fi",
+            "command": "if [ -z \"${BRAIN_SYNC_ACTIVE:-}\" ] && [ -f \"${HOME}/.claude/brain-config.json\" ]; then bash \"${CLAUDE_PLUGIN_ROOT}/scripts/export.sh\" --memory-only --quiet > /dev/null; fi",
             "timeout": 10,
             "async": true
           }

--- a/scripts/evolve.sh
+++ b/scripts/evolve.sh
@@ -117,7 +117,14 @@ SCHEMA='{
 # ── Run analysis ───────────────────────────────────────────────────────────────
 log_info "Analyzing brain for evolution opportunities..."
 
+# Fork-bomb guard at the spawn site: evolve.sh is invoked directly by the
+# brain-evolve skill (bypassing pull.sh), so the guard may not be set yet.
+# Export it defensively right before claude -p so the child process inherits
+# it and its SessionStart hook no-ops instead of firing a nested pull.sh.
+# --no-session-persistence keeps this headless one-shot out of the session list.
+export BRAIN_SYNC_ACTIVE=1
 RESULT=$(claude -p "$PROMPT" \
+  --no-session-persistence \
   --output-format json \
   --json-schema "$SCHEMA" \
   --model sonnet \

--- a/scripts/export.sh
+++ b/scripts/export.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 # export.sh — Serialize local brain state to a JSON snapshot
 set -euo pipefail
+
+# Note: this script is intentionally callable while BRAIN_SYNC_ACTIVE is set —
+# it is invoked as a child of push.sh, which has already set the flag. Fork-bomb
+# protection lives in the SessionStart/SessionEnd/PreCompact hooks (which suppress
+# the hook when the flag is inherited via env), not here.
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/common.sh"
 

--- a/scripts/merge-semantic.sh
+++ b/scripts/merge-semantic.sh
@@ -3,6 +3,13 @@
 # Uses claude -p with structured output for intelligent deduplication and conflict resolution
 # Supports N-way merge: all machine snapshots merged in a single prompt
 set -euo pipefail
+
+# Fork-bomb note: this script runs the headless `claude -p` below, whose child
+# process re-fires the brain-sync SessionStart hook. It is normally invoked as a
+# child of pull.sh (which already exports BRAIN_SYNC_ACTIVE), but we re-export
+# the guard defensively right before the claude -p call so the invariant "any
+# claude -p we spawn runs with the guard set" holds at every spawn site.
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/common.sh"
 
@@ -152,7 +159,12 @@ SCHEMA='{
 # ── Call claude -p ─────────────────────────────────────────────────────────────
 log_info "Running semantic merge via claude..."
 
+# Guard at the spawn site (see header note): keep BRAIN_SYNC_ACTIVE in the env
+# so the claude -p child inherits it and its SessionStart hook no-ops.
+# --no-session-persistence keeps this headless one-shot out of the session list.
+export BRAIN_SYNC_ACTIVE=1
 RESULT=$(cat "$PROMPT_FILE" | claude -p - \
+  --no-session-persistence \
   --output-format json \
   --json-schema "$SCHEMA" \
   --model sonnet \
@@ -160,26 +172,36 @@ RESULT=$(cat "$PROMPT_FILE" | claude -p - \
   --max-budget-usd "$MAX_BUDGET" \
   2>/dev/null) || {
   log_warn "claude -p failed. Falling back to concatenation merge."
-  # Fallback: use first snapshot as base, append others with markers
+  # Fallback: use first snapshot as base, append others with markers.
+  # Idempotency: strip any pre-existing "Unmerged content" sections from BOTH
+  # the base and each incoming snapshot before comparison. Without this, every
+  # fallback run grew CLAUDE.md by one marker block — it accumulated identical
+  # copies across repeated syncs in the wild before this fix landed.
   base_snapshot="${SNAPSHOTS[0]}"
   cp "$base_snapshot" "$OUTPUT"
-  
-  # Collect unique CLAUDE.md content to append
+
+  # Strip everything from the first marker onward.
+  strip_markers() {
+    awk '/<!-- === Unmerged content from .* === -->/{exit} {print}' <<< "$1"
+  }
+
   base_claude_md=$(jq -r '.declarative.claude_md.content // ""' "$base_snapshot")
-  fallback_claude_md="$base_claude_md"
-  
+  base_claude_md_clean=$(strip_markers "$base_claude_md")
+  fallback_claude_md="$base_claude_md_clean"
+
   for snapshot_file in "${SNAPSHOTS[@]:1}"; do
     machine_name=$(jq -r '.machine.name // "unknown"' "$snapshot_file")
     claude_md_content=$(jq -r '.declarative.claude_md.content // ""' "$snapshot_file")
-    
-    if [ -n "$claude_md_content" ] && [ "$claude_md_content" != "$base_claude_md" ]; then
+    claude_md_clean=$(strip_markers "$claude_md_content")
+
+    if [ -n "$claude_md_clean" ] && [ "$claude_md_clean" != "$base_claude_md_clean" ]; then
       fallback_claude_md="${fallback_claude_md}
 
 <!-- === Unmerged content from ${machine_name} === -->
-${claude_md_content}"
+${claude_md_clean}"
     fi
   done
-  
+
   # Update output with concatenated content
   tmp=$(brain_mktemp)
   jq --arg content "$fallback_claude_md" \

--- a/scripts/pull.sh
+++ b/scripts/pull.sh
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
 # pull.sh — Pull latest from remote, merge, and apply locally
 set -euo pipefail
+
+# Fork-bomb hard-stop: refuse to run if already nested inside an active sync.
+# The headless `claude -p` calls in merge-semantic.sh/evolve.sh re-trigger the
+# brain-sync SessionStart hook in the child process; without this guard that
+# hook starts another pull.sh, which spawns another claude -p, ad infinitum.
+# pull.sh/push.sh export BRAIN_SYNC_ACTIVE; the claude -p child inherits it and
+# its SessionStart hook (and this guard) no-op instead of recursing.
+if [ -n "${BRAIN_SYNC_ACTIVE:-}" ]; then
+  echo "[claude-brain] pull: BRAIN_SYNC_ACTIVE set — refusing recursive invocation." >&2
+  exit 0
+fi
+export BRAIN_SYNC_ACTIVE=1
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/common.sh"
 

--- a/scripts/push.sh
+++ b/scripts/push.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 # push.sh — Export brain snapshot and push to Git remote
 set -euo pipefail
+
+# Fork-bomb hard-stop: refuse to run if already nested inside an active sync.
+# See pull.sh for the full rationale — the env-var guard is inherited by the
+# claude -p child and keeps its SessionStart hook from recursing.
+if [ -n "${BRAIN_SYNC_ACTIVE:-}" ]; then
+  echo "[claude-brain] push: BRAIN_SYNC_ACTIVE set — refusing recursive invocation." >&2
+  exit 0
+fi
+export BRAIN_SYNC_ACTIVE=1
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/common.sh"
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -917,6 +917,164 @@ EOF
   pass "import continued past keybindings step ('Brain import complete' logged)"
 }
 
+test_sync_guard_blocks_recursion() {
+  section "Fork-bomb guard: sync scripts no-op when BRAIN_SYNC_ACTIVE is set"
+
+  # pull.sh and push.sh must exit immediately (exit 0, no work) when the guard
+  # env var is already set — this is what stops the claude -p child's
+  # SessionStart hook from firing a nested sync. We run them with the guard set
+  # and assert they emit the refusal message and never reach git/fetch work.
+  local out
+  out=$(BRAIN_SYNC_ACTIVE=1 bash "$PROJECT_DIR/scripts/pull.sh" --quiet 2>&1) || true
+  if echo "$out" | grep -q "BRAIN_SYNC_ACTIVE set — refusing recursive invocation"; then
+    pass "pull.sh refuses to run when BRAIN_SYNC_ACTIVE is set"
+  else
+    fail "pull.sh did not no-op under BRAIN_SYNC_ACTIVE (got: $out)"
+  fi
+
+  out=$(BRAIN_SYNC_ACTIVE=1 bash "$PROJECT_DIR/scripts/push.sh" --quiet 2>&1) || true
+  if echo "$out" | grep -q "BRAIN_SYNC_ACTIVE set — refusing recursive invocation"; then
+    pass "push.sh refuses to run when BRAIN_SYNC_ACTIVE is set"
+  else
+    fail "push.sh did not no-op under BRAIN_SYNC_ACTIVE (got: $out)"
+  fi
+
+  # The guard must check before doing any real work: neither script should have
+  # touched the brain repo (no new commits) while blocked.
+  local head_before head_after
+  head_before=$(cd "$BRAIN_REPO" && git rev-parse HEAD)
+  BRAIN_SYNC_ACTIVE=1 bash "$PROJECT_DIR/scripts/pull.sh" --quiet >/dev/null 2>&1 || true
+  BRAIN_SYNC_ACTIVE=1 bash "$PROJECT_DIR/scripts/push.sh" --quiet >/dev/null 2>&1 || true
+  head_after=$(cd "$BRAIN_REPO" && git rev-parse HEAD)
+  [ "$head_before" = "$head_after" ] \
+    && pass "blocked sync scripts performed no repo work" \
+    || fail "blocked sync scripts mutated the brain repo"
+}
+
+test_hooks_guard_pattern() {
+  section "Fork-bomb guard: hooks skip when BRAIN_SYNC_ACTIVE is set"
+
+  # The three sync hooks must each gate their command on an unset
+  # BRAIN_SYNC_ACTIVE so an inherited guard suppresses the hook entirely
+  # (defense-in-depth on top of the in-script guard).
+  local cmds
+  cmds=$(jqr '.hooks | to_entries[] | .value[].hooks[].command' "$PROJECT_DIR/hooks/hooks.json")
+  local total guarded
+  total=$(echo "$cmds" | grep -c 'brain-config.json')
+  guarded=$(echo "$cmds" | grep -c 'BRAIN_SYNC_ACTIVE')
+  if [ "$total" -eq "$guarded" ] && [ "$total" -ge 3 ]; then
+    pass "all $total sync hooks gate on BRAIN_SYNC_ACTIVE"
+  else
+    fail "only $guarded of $total sync hooks gate on BRAIN_SYNC_ACTIVE"
+  fi
+
+  # Verify the gate actually short-circuits: emulate the hook condition with the
+  # guard set and confirm the body is skipped.
+  local ran="no"
+  # shellcheck disable=SC2016
+  if [ -z "${BRAIN_SYNC_ACTIVE:-}" ]; then ran="yes"; fi
+  BRAIN_SYNC_ACTIVE=1
+  local ran2="no"
+  if [ -z "${BRAIN_SYNC_ACTIVE:-}" ]; then ran2="yes"; fi
+  unset BRAIN_SYNC_ACTIVE
+  [ "$ran" = "yes" ] && [ "$ran2" = "no" ] \
+    && pass "hook gate condition short-circuits when guard is set" \
+    || fail "hook gate condition did not short-circuit (unset=$ran, set=$ran2)"
+}
+
+test_evolve_sets_guard_before_claude() {
+  section "Fork-bomb guard: evolve.sh + merge-semantic.sh set guard at spawn site"
+
+  # evolve.sh is invoked directly by the brain-evolve skill, bypassing pull.sh,
+  # so it must export BRAIN_SYNC_ACTIVE itself right before claude -p. Verify the
+  # export appears textually before the claude -p invocation in both scripts.
+  for script in evolve.sh merge-semantic.sh; do
+    local f="$PROJECT_DIR/scripts/$script"
+    local export_line claude_line
+    export_line=$(grep -n '^export BRAIN_SYNC_ACTIVE=1' "$f" | tail -1 | cut -d: -f1)
+    # Match the actual invocation (RESULT=$(... claude -p ...)), not the prose
+    # mentions in comments. The real call assigns to RESULT and pipes/passes the
+    # prompt, so anchor on the `claude -p` that is part of a command, excluding
+    # comment lines.
+    claude_line=$(grep -nE '(\$\(claude -p|\| claude -p|claude -p -|claude -p ")' "$f" \
+      | grep -v '^[0-9]*:#' | grep -v '^[0-9]*: *#' | head -1 | cut -d: -f1)
+    if [ -n "$export_line" ] && [ -n "$claude_line" ] && [ "$export_line" -lt "$claude_line" ]; then
+      pass "$script exports guard before claude -p (line $export_line < $claude_line)"
+    else
+      fail "$script does not export guard before claude -p (export=$export_line, claude=$claude_line)"
+    fi
+  done
+}
+
+test_fallback_merge_is_idempotent() {
+  section "Idempotent fallback: repeated concatenation merge converges"
+
+  # Reproduces the in-the-wild bug: the pre-fix fallback appended an "Unmerged
+  # content" marker block on every run, so CLAUDE.md grew by one copy per sync.
+  # We run the fixed merge-semantic.sh fallback path twice, feeding round 2 the
+  # output of round 1, and assert the content does not grow.
+  #
+  # Force the fallback path deterministically by making `claude` unavailable to
+  # the script via PATH stubbing — but the script exits 0 ("claude CLI not
+  # found") in that case, so instead we stub a `claude` that always fails,
+  # which drives the `|| { ... fallback ... }` branch.
+  local mtdir="$TEST_DIR/idem"
+  mkdir -p "$mtdir/bin"
+  cat > "$mtdir/bin/claude" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+  chmod +x "$mtdir/bin/claude"
+
+  # Two snapshots with distinct CLAUDE.md so the fallback appends one marker.
+  cat > "$mtdir/base.json" <<'EOF'
+{"schema_version":"1.0.0","machine":{"id":"a","name":"machine-a"},"declarative":{"claude_md":{"content":"# Base rules\n- alpha","hash":""}},"procedural":{},"experiential":{"auto_memory":{}},"environmental":{}}
+EOF
+  cat > "$mtdir/other.json" <<'EOF'
+{"schema_version":"1.0.0","machine":{"id":"b","name":"machine-b"},"declarative":{"claude_md":{"content":"# Other rules\n- beta","hash":""}},"procedural":{},"experiential":{"auto_memory":{}},"environmental":{}}
+EOF
+
+  # Round 1: base + other → out1 (should contain exactly one marker block)
+  PATH="$mtdir/bin:$PATH" bash "$PROJECT_DIR/scripts/merge-semantic.sh" \
+    "$mtdir/out1.json" "$mtdir/base.json" "$mtdir/other.json" >/dev/null 2>&1 || true
+
+  if [ ! -f "$mtdir/out1.json" ]; then
+    fail "fallback merge produced no output"
+    return
+  fi
+  local markers1
+  markers1=$(jqr '.declarative.claude_md.content' "$mtdir/out1.json" | grep -c 'Unmerged content from' || true)
+
+  # Round 2: feed out1 back in as the base, merge with the same other snapshot.
+  # The fixed strip_markers logic must drop the prior marker before re-appending,
+  # so the marker count stays at 1 (not 2) and content length does not balloon.
+  PATH="$mtdir/bin:$PATH" bash "$PROJECT_DIR/scripts/merge-semantic.sh" \
+    "$mtdir/out2.json" "$mtdir/out1.json" "$mtdir/other.json" >/dev/null 2>&1 || true
+
+  local markers2 len1 len2
+  markers2=$(jqr '.declarative.claude_md.content' "$mtdir/out2.json" | grep -c 'Unmerged content from' || true)
+  len1=$(jqr '.declarative.claude_md.content' "$mtdir/out1.json" | wc -c | tr -d ' ')
+  len2=$(jqr '.declarative.claude_md.content' "$mtdir/out2.json" | wc -c | tr -d ' ')
+
+  if [ "$markers1" = "1" ]; then
+    pass "first fallback appends exactly one marker block"
+  else
+    fail "first fallback produced $markers1 marker blocks (expected 1)"
+  fi
+
+  if [ "$markers2" = "1" ]; then
+    pass "repeated fallback stays at one marker block (idempotent)"
+  else
+    fail "repeated fallback accumulated $markers2 marker blocks (the bug)"
+  fi
+
+  if [ "$len2" -le "$len1" ]; then
+    pass "repeated fallback does not grow CLAUDE.md ($len2 ≤ $len1 bytes)"
+  else
+    fail "repeated fallback grew CLAUDE.md from $len1 to $len2 bytes (the bug)"
+  fi
+}
+
 # ── Run ────────────────────────────────────────────────────────────────────────
 echo -e "${CYAN}claude-brain integration tests${NC}"
 echo "================================"
@@ -945,6 +1103,10 @@ test_semantic_merge_fallback
 test_wsl_detection
 test_encryption_roundtrip
 test_keybindings_shape_mismatch
+test_sync_guard_blocks_recursion
+test_hooks_guard_pattern
+test_evolve_sets_guard_before_claude
+test_fallback_merge_is_idempotent
 
 echo ""
 echo "================================"


### PR DESCRIPTION
## Summary

Closes the `SessionStart`-hook fork bomb, keeps Claude.ai OAuth auth working during semantic merges, and makes the concatenation fallback idempotent. This is the **fixes-only** PR — per review feedback, the run-logging feature has been split into a separate PR (#TBD, stacked on this branch) so these urgent, low-risk fixes can land immediately.

Rebased onto the latest `main` (now includes #43, #44, #45).

## What's in here

- **Fork-bomb guard (`BRAIN_SYNC_ACTIVE`).** `pull.sh`/`push.sh` export the sentinel and exit early if it's already set. Per review point 1, `evolve.sh` and `merge-semantic.sh` now **also** export it defensively right before their `claude -p` call, so the invariant "any `claude -p` we spawn runs with the guard set" holds at every spawn site — including the direct `evolve.sh` invocation from the `brain-evolve` skill, which bypasses `pull.sh`. The three sync hooks additionally gate on the var for defense-in-depth.
- **OAuth fix.** Removes the earlier `--bare` workaround (which disabled keychain reads and broke OAuth) in favor of the env-var guard.
- **Idempotent fallback.** The concatenation fallback now strips pre-existing "Unmerged content" marker blocks from both base and incoming snapshots before re-appending, so repeated fallback runs converge instead of growing `CLAUDE.md` by one duplicate copy per sync.
- **`--no-session-persistence`** on the headless calls so they don't pollute the session picker.

## Addressing the review

| Review point | Status |
|---|---|
| 1. Guard at every spawn site | ✅ `evolve.sh` + `merge-semantic.sh` now export the guard before `claude -p` |
| 2. `trap … RETURN` → `EXIT` | ↪️ Moved to the run-logging PR — the marker + its trap are part of that feature; without the marker there is no trap. The corrected `trap … EXIT` lands there. |
| 3. Run-log `chmod 600` | ↪️ Run-logging PR |
| 4. Tests | ✅ (fixes) — fork-bomb guard no-op, hook-gate, spawn-site guard, idempotent-fallback regression. Logging tests in the logging PR. |
| 5. Split run-logging | ✅ Done — this PR is fixes-only |

## Tests

Added regression tests for each headline fix:
- `test_sync_guard_blocks_recursion` — pull/push no-op (and touch nothing) under `BRAIN_SYNC_ACTIVE`
- `test_hooks_guard_pattern` — all three sync hooks gate on the var
- `test_evolve_sets_guard_before_claude` — `evolve.sh`/`merge-semantic.sh` export the guard before `claude -p`
- `test_fallback_merge_is_idempotent` — repeated fallback converges (the in-the-wild bug)

Suite green at **58 passed, 0 failed, 1 skipped** (age not installed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
