### PR TITLE
fix(register-machine): write brain-config.json atomically

### DIFF
--- a/scripts/register-machine.sh
+++ b/scripts/register-machine.sh
@@ -108,7 +108,7 @@ register_machine() {
             identity: $identity,
             recipients: $recipients
           }
-        }' > "$BRAIN_CONFIG"
+        }' > "${BRAIN_CONFIG}.tmp.$$" && mv -f "${BRAIN_CONFIG}.tmp.$$" "$BRAIN_CONFIG"
     else
       jq -n \
         --arg ver "1.0.0" \
@@ -138,7 +138,7 @@ register_machine() {
           encryption: {
             enabled: false
           }
-        }' > "$BRAIN_CONFIG"
+        }' > "${BRAIN_CONFIG}.tmp.$$" && mv -f "${BRAIN_CONFIG}.tmp.$$" "$BRAIN_CONFIG"
     fi
 
   # Update machines.json in brain repo if it exists


### PR DESCRIPTION
Fixes #48.

`register-machine.sh` ended both `jq` branches with a bare truncating redirect, so the shell emptied `brain-config.json` before `jq` wrote anything. Since `register-machine.sh` runs on every `push.sh` (`push.sh:54`), any failure or signal in that window — most reliably the async `SessionEnd` hook hitting its timeout — left the config permanently at 0 bytes.

The cascade from there: empty config → `machine_id` resolves to `""` → snapshots land in `machines//brain-snapshot.json` → a later re-registration reads the empty id and mints a new one, orphaning the machine's existing snapshot in the repo.

These two sites were the only writers of this file in the repo not already using tmp + `mv` (`push.sh:67-69`/`73-75`, `pull.sh:132-133`/`143-144`/`155-156`, `evolve.sh:167-168` all do). This makes them match.

```diff
-        }' > "$BRAIN_CONFIG"
+        }' > "${BRAIN_CONFIG}.tmp.$$" && mv -f "${BRAIN_CONFIG}.tmp.$$" "$BRAIN_CONFIG"
```

`mv` within the same directory is a `rename()`, so the config is either the old content or the new content and never empty. On failure the original survives and only a stray `.tmp.$$` is left behind.

### Verification

Applied to three installs across two machines (`primary` + `follower`, both macOS). After the change, repeated `push.sh` runs leave a valid non-empty config with `machine_id`, `merge_role`, and `encryption` intact, no stray `.tmp` files, and no `machines//` orphan. Snapshots stay age-encrypted. `bash -n` clean.

Branched off `main` @ `09242f0`.
